### PR TITLE
Colaps curl and tar to reduce linecount.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,7 @@ ENV SBT_VERSION 0.13.8
 
 # Install Scala
 RUN \
-  cd /root && \
-  curl -o scala-$SCALA_VERSION.tgz http://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz && \
-  tar -xf scala-$SCALA_VERSION.tgz && \
-  rm scala-$SCALA_VERSION.tgz && \
+  curl -fsL http://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz |tar xf - -C /root/ && \
   echo >> /root/.bashrc && \
   echo 'export PATH=~/scala-$SCALA_VERSION/bin:$PATH' >> /root/.bashrc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,9 @@ ENV SCALA_VERSION 2.11.7
 ENV SBT_VERSION 0.13.8
 
 # Install Scala
+## Piping curl directly in tar 
 RUN \
-  curl -fsL http://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz |tar xfz - -C /root/ && \
+  curl -fsL http://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /root/ && \
   echo >> /root/.bashrc && \
   echo 'export PATH=~/scala-$SCALA_VERSION/bin:$PATH' >> /root/.bashrc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ ENV SBT_VERSION 0.13.8
 
 # Install Scala
 RUN \
-  curl -fsL http://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz |tar xf - -C /root/ && \
+  curl -fsL http://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz |tar xfz - -C /root/ && \
   echo >> /root/.bashrc && \
   echo 'export PATH=~/scala-$SCALA_VERSION/bin:$PATH' >> /root/.bashrc
 


### PR DESCRIPTION
Pipe directly to tar
 - `xfz` to e**X**tract to a **F**ile using the **Z**ip format. 
 - `-C` changes to the specified directory
 - `-` reads from stdin, hence the pipe