### PR TITLE
Download associated jars for faster compilations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,8 @@ RUN \
   dpkg -i sbt-$SBT_VERSION.deb && \
   rm sbt-$SBT_VERSION.deb && \
   apt-get update && \
-  apt-get install sbt
+  apt-get install sbt && \
+  sbt sbtVersion
 
 # Define working directory
 WORKDIR /root


### PR DESCRIPTION
Do a version check which will force a download of all the jars required to build against the specified sbt version.  This saves you the time of having to download all these when you use this container to actually build something.