### PR TITLE
Fix string interpolating in scala path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN touch /usr/lib/jvm/java-8-openjdk-amd64/release
 RUN \
   curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /root/ && \
   echo >> /root/.bashrc && \
-  echo 'export PATH=~/scala-$SCALA_VERSION/bin:$PATH' >> /root/.bashrc
+  echo "export PATH=~/scala-$SCALA_VERSION/bin:$PATH" >> /root/.bashrc
 
 # Install sbt
 RUN \


### PR DESCRIPTION
Specific property of single quotes in Bash is that it does not interpolate variable in string.

For example:

```bash
name=John
echo 'name=$name'
# name=$name
echo "name=$name"
# name=John
```

As a result Scala directory is not added to path in `.bashrc` => you cannot use `scala`.

Example of such wrong `.bashrc`:

```
# Some more alias to avoid making mistakes:
# alias rm='rm -i'
# alias cp='cp -i'
# alias mv='mv -i'

export PATH=~/scala-$SCALA_VERSION/bin:$PATH
```