### PR TITLE
Slim version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@
 FROM openjdk:8u151
 
 # Env variables
-ENV SCALA_VERSION 2.12.4
-ENV SBT_VERSION 1.1.1
+ENV SCALA_VERSION 2.12.5
+ENV SBT_VERSION 1.1.2
 
 # Scala expects this file
 RUN touch /usr/lib/jvm/java-8-openjdk-amd64/release

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 #
 
 # Pull base image
-FROM openjdk:8u151
+FROM openjdk:8u151-slim
 
 # Env variables
 ENV SCALA_VERSION 2.12.5
@@ -17,6 +17,7 @@ RUN touch /usr/lib/jvm/java-8-openjdk-amd64/release
 # Install Scala
 ## Piping curl directly in tar
 RUN \
+  apt-get update && apt-get install -y curl && \
   curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /root/ && \
   echo >> /root/.bashrc && \
   echo "export PATH=~/scala-$SCALA_VERSION/bin:$PATH" >> /root/.bashrc


### PR DESCRIPTION
Hi again @hseeberger 

Could you be interested in using the "openjdk slim" instead of the "heavy" version ?

Here is what change:

```
➜  scala-sbt git:(master) ✗ docker images                         
REPOSITORY          TAG                 IMAGE ID            CREATED                  SIZE
scala-sbt           jules-slim          e055c4fe8a93        Less than a second ago   385MB
scala-sbt           jules               9cbc578f363b        5 minutes ago            870MB
openjdk             8u151-slim          b1490ef2f27b        13 days ago              244MB
openjdk             8u151               a30a1e547e6d        13 days ago              737MB
```

385MB instead of 870MB