### PR TITLE
Update Java open base image and upgrade sbt version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,11 @@
 #
 
 # Pull base image
-FROM openjdk:8u171
+FROM openjdk:8u172
 
 # Env variables
 ENV SCALA_VERSION 2.12.6
-ENV SBT_VERSION 1.1.5
+ENV SBT_VERSION 1.1.6
 
 # Scala expects this file
 RUN touch /usr/lib/jvm/java-8-openjdk-amd64/release


### PR DESCRIPTION
This PR upgrades Java 8 base image to the latest version `8u172` (http://www.oracle.com/technetwork/java/javase/documentation/8u-relnotes-2225394.html) and SBT to `1.1.6`