### PR TITLE
Run as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,5 +33,14 @@ RUN \
   sbt compile && \
   rm -r project && rm build.sbt && rm Temp.scala && rm -r target
 
+# Add and use user sbt
+RUN groupadd --gid 1001 sbtuser && useradd --gid 1001 --uid 1001 sbtuser --shell /bin/bash
+RUN chown -R sbtuser:sbtuser /opt
+RUN mkdir /home/sbtuser && chown -R sbtuser:sbtuser /home/sbtuser
+RUN mkdir /logs && chown -R sbtuser:sbtuser /logs
+USER sbtuser
+
 # Define working directory
-WORKDIR /root
+WORKDIR /home/sbtuser
+
+CMD ["sbt"]


### PR DESCRIPTION
 - running docker as root can be problematic (one has root privileges on
 the host)
 - running docker as root is disallow in some environments
 - this adds a users sbtuser (to keep it separate from the deamon user
 sbt)
 - and switches to the user sbtuser
 - it changes the CMD to sbt