### PR TITLE
non-root user causes image to not be usable on drone #67

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,8 +26,8 @@ RUN mkdir /home/sbtuser && chown -R sbtuser:sbtuser /home/sbtuser
 RUN mkdir /logs && chown -R sbtuser:sbtuser /logs
 USER sbtuser
 
-# Define working directory
-WORKDIR /home/sbtuser
+# Switch working directory
+WORKDIR /home/sbtuser  
 
 # Install Scala
 ## Piping curl directly in tar
@@ -46,4 +46,16 @@ RUN \
   sbt compile && \
   rm -r project && rm build.sbt && rm Temp.scala && rm -r target
 
-CMD ["sbt"]
+# Link everything into root as well
+# This allows users of this container to choose, whether they want to run the container as sbtuser (non-root) or as root
+USER root
+RUN \
+  echo "export PATH=/home/sbtuser/scala-$SCALA_VERSION/bin:$PATH" >> /root/.bashrc && \
+  ln -s /home/sbtuser/.ivy2 /root/.ivy2 && \
+  ln -s /home/sbtuser/.sbt /root/.sbt
+
+# Switch working directory back to root
+## Users wanting to use this container as non-root should combine the two following arguments
+## -u sbtuser
+## -w /home/sbtuser
+WORKDIR /root  

--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ docker build -t hseeberger/scala-sbt github.com/hseeberger/scala-sbt
 docker run -it --rm hseeberger/scala-sbt
 ```
 
+### Alternative commands ###
+The container contains `bash`, `scala` and `sbt`.
+
+```
+docker run -it --rm hseeberger/scala-sbt scala
+```
+
+### Non-root ###
+The container is prepared to be used with a non-root user called `sbtuser`
+
+```
+docker run -it --rm -u sbtuser -w /home/sbtuser hseeberger/scala-sbt
+```
 
 ## Contribution policy ##
 


### PR DESCRIPTION
 - revert back to root as default user
 - make sure Scala is available for root and sbtuser
 - make sure SBT is prepared for root and sbtuser
 - fixes #67