### PR TITLE
add scala to the path and fix coursier cache

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -22,6 +22,15 @@ RUN \
   apt-get update && \
   apt-get install sbt
 
+# Install Scala
+## Piping curl directly in tar
+RUN \
+  curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /usr/share && \
+  mv /usr/share/scala-$SCALA_VERSION /usr/share/scala && \
+  chown -R root:root /usr/share/scala && \
+  chmod -R 755 /usr/share/scala && \
+  ln -s /usr/share/scala/bin/scala /usr/local/bin/scala
+
 # Add and use user sbtuser
 RUN groupadd --gid 1001 sbtuser && useradd --gid 1001 --uid 1001 sbtuser --shell /bin/bash
 RUN chown -R sbtuser:sbtuser /opt
@@ -30,16 +39,9 @@ RUN mkdir /logs && chown -R sbtuser:sbtuser /logs
 USER sbtuser
 
 # Switch working directory
-WORKDIR /home/sbtuser  
+WORKDIR /home/sbtuser
 
-# Install Scala
-## Piping curl directly in tar
-RUN \
-  curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /home/sbtuser/ && \
-  echo >> /home/sbtuser/.bashrc && \
-  echo "export PATH=~/scala-$SCALA_VERSION/bin:$PATH" >> /home/sbtuser/.bashrc
-
-# Prepare sbt
+# Prepare sbt (warm cache)
 RUN \
   sbt sbtVersion && \
   mkdir -p project && \
@@ -53,7 +55,7 @@ RUN \
 # This allows users of this container to choose, whether they want to run the container as sbtuser (non-root) or as root
 USER root
 RUN \
-  echo "export PATH=/home/sbtuser/scala-$SCALA_VERSION/bin:$PATH" >> /root/.bashrc && \
+  ln -s /home/sbtuser/.cache /root/.cache && \
   ln -s /home/sbtuser/.ivy2 /root/.ivy2 && \
   ln -s /home/sbtuser/.sbt /root/.sbt
 

--- a/oracle/Dockerfile
+++ b/oracle/Dockerfile
@@ -22,6 +22,15 @@ RUN \
   yum -y update && \
   yum -y install sbt
 
+# Install Scala
+## Piping curl directly in tar
+RUN \
+  curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /usr/share && \
+  mv /usr/share/scala-$SCALA_VERSION /usr/share/scala && \
+  chown -R root:root /usr/share/scala && \
+  chmod -R 755 /usr/share/scala && \
+  ln -s /usr/share/scala/bin/scala /usr/local/bin/scala
+
 # Add and use user sbtuser
 RUN groupadd --gid 1001 sbtuser && useradd --gid 1001 --uid 1001 sbtuser --shell /bin/bash
 RUN chown -R sbtuser:sbtuser /opt
@@ -32,14 +41,7 @@ USER sbtuser
 # Switch working directory
 WORKDIR /home/sbtuser  
 
-# Install Scala
-## Piping curl directly in tar
-RUN \
-  curl -fsL https://downloads.typesafe.com/scala/$SCALA_VERSION/scala-$SCALA_VERSION.tgz | tar xfz - -C /home/sbtuser/ && \
-  echo >> /home/sbtuser/.bashrc && \
-  echo "export PATH=~/scala-$SCALA_VERSION/bin:$PATH" >> /home/sbtuser/.bashrc
-
-# Prepare sbt
+# Prepare sbt (warm cache)
 RUN \
   sbt sbtVersion && \
   mkdir -p project && \
@@ -53,7 +55,7 @@ RUN \
 # This allows users of this container to choose, whether they want to run the container as sbtuser (non-root) or as root
 USER root
 RUN \
-  echo "export PATH=/home/sbtuser/scala-$SCALA_VERSION/bin:$PATH" >> /root/.bashrc && \
+  ln -s /home/sbtuser/.cache /root/.cache && \
   ln -s /home/sbtuser/.ivy2 /root/.ivy2 && \
   ln -s /home/sbtuser/.sbt /root/.sbt
 


### PR DESCRIPTION
This PR makes sure scala is installed globally so it can be run as any user without `.bashrc` #89

Also fixes sharing of the scala 1.3.x coursier cache #91

```
> docker build .
Sending build context to Docker daemon  4.096kB
Step 1/18 : ARG BASE_IMAGE_TAG
...
Successfully built fc1db2e90131
> docker run -it --rm -u sbtuser -w /home/sbtuser fc1db2e90131 scala
Welcome to Scala 2.13.1 (OpenJDK 64-Bit Server VM, Java 1.8.0_222).
Type in expressions for evaluation. Or try :help.
```

