### PR TITLE
Use ENVs and ARGs for USER_ID and GROUP_ID for sbtuser

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ docker build \
   --build-arg BASE_IMAGE_TAG="8u212-b04-jdk-stretch" \
   --build-arg SBT_VERSION="1.3.3" \
   --build-arg SCALA_VERSION="2.13.1" \
+  --build-arg USER_ID=1001 \
+  --build-arg GROUP_ID=1001 \
   -t hseeberger/scala-sbt \
   github.com/hseeberger/scala-sbt.git#:debian
 ```
@@ -31,6 +33,8 @@ docker build \
   --build-arg BASE_IMAGE_TAG="11.0.2-jdk-oraclelinux7" \
   --build-arg SBT_VERSION="1.3.3" \
   --build-arg SCALA_VERSION="2.13.1" \
+  --build-arg USER_ID=1001 \
+  --build-arg GROUP_ID=1001 \
   -t hseeberger/scala-sbt \
   github.com/hseeberger/scala-sbt.git#:oracle
 ```

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -13,6 +13,10 @@ ARG SCALA_VERSION
 ENV SCALA_VERSION ${SCALA_VERSION:-2.13.1}
 ARG SBT_VERSION
 ENV SBT_VERSION ${SBT_VERSION:-1.3.3}
+ARG USER_ID
+ENV USER_ID ${USER_ID:-1001}
+ARG GROUP_ID 
+ENV GROUP_ID ${GROUP_ID:-1001}
 
 # Install sbt
 RUN \
@@ -32,7 +36,7 @@ RUN \
   ln -s /usr/share/scala/bin/scala /usr/local/bin/scala
 
 # Add and use user sbtuser
-RUN groupadd --gid 1001 sbtuser && useradd --gid 1001 --uid 1001 sbtuser --shell /bin/bash
+RUN groupadd --gid $GROUP_ID sbtuser && useradd --gid $GROUP_ID --uid $USER_ID sbtuser --shell /bin/bash
 RUN chown -R sbtuser:sbtuser /opt
 RUN mkdir /home/sbtuser && chown -R sbtuser:sbtuser /home/sbtuser
 RUN mkdir /logs && chown -R sbtuser:sbtuser /logs

--- a/graalvm-ce/Dockerfile
+++ b/graalvm-ce/Dockerfile
@@ -14,6 +14,10 @@ ENV SCALA_VERSION ${SCALA_VERSION:-2.13.1}
 ARG SBT_VERSION
 ENV SBT_VERSION ${SBT_VERSION:-1.3.3}
 ENV JAVA_OPTS -XX:+UseG1GC 
+ARG USER_ID
+ENV USER_ID ${USER_ID:-1001}
+ARG GROUP_ID 
+ENV GROUP_ID ${GROUP_ID:-1001}
 
 # Install sbt
 RUN \
@@ -33,7 +37,7 @@ RUN \
   ln -s /usr/share/scala/bin/scala /usr/local/bin/scala
 
 # Add and use user sbtuser
-RUN groupadd --gid 1001 sbtuser && useradd --gid 1001 --uid 1001 sbtuser --shell /bin/bash
+RUN groupadd --gid $GROUP_ID sbtuser && useradd --gid $GROUP_ID --uid $USER_ID sbtuser --shell /bin/bash
 RUN chown -R sbtuser:sbtuser /opt
 # RUN mkdir /home/sbtuser && chown -R sbtuser:sbtuser /home/sbtuser
 RUN mkdir /logs && chown -R sbtuser:sbtuser /logs

--- a/hooks/build.sh
+++ b/hooks/build.sh
@@ -8,5 +8,7 @@ docker build $DOCKER_CONTEXT \
     -t "$TAG" \
     --build-arg BASE_IMAGE_TAG=$BASE_IMAGE_TAG \
     --build-arg SBT_VERSION=$SBT_VERSION \
-    --build-arg SCALA_VERSION=$SCALA_VERSION
+    --build-arg SCALA_VERSION=$SCALA_VERSION \
+    --build-arg USER_ID=$USER_ID \
+    --build-arg GROUP_ID=$GROUP_ID
 

--- a/oracle/Dockerfile
+++ b/oracle/Dockerfile
@@ -13,6 +13,10 @@ ARG SCALA_VERSION
 ENV SCALA_VERSION ${SCALA_VERSION:-2.13.1}
 ARG SBT_VERSION
 ENV SBT_VERSION ${SBT_VERSION:-1.3.3}
+ARG USER_ID
+ENV USER_ID ${USER_ID:-1001}
+ARG GROUP_ID 
+ENV GROUP_ID ${GROUP_ID:-1001}
 
 # Install sbt
 RUN \
@@ -32,7 +36,7 @@ RUN \
   ln -s /usr/share/scala/bin/scala /usr/local/bin/scala
 
 # Add and use user sbtuser
-RUN groupadd --gid 1001 sbtuser && useradd --gid 1001 --uid 1001 sbtuser --shell /bin/bash
+RUN groupadd --gid $GROUP_ID sbtuser && useradd --gid $GROUP_ID --uid $USER_ID sbtuser --shell /bin/bash
 RUN chown -R sbtuser:sbtuser /opt
 # RUN mkdir /home/sbtuser && chown -R sbtuser:sbtuser /home/sbtuser
 RUN mkdir /logs && chown -R sbtuser:sbtuser /logs


### PR DESCRIPTION
The problem with mounted volumes file ownership (sbtuser becomes owner of host's files) occurs only on Linux host machines when running the docker container with non-root user `sbtuser`  that has `uid:gid` (`1001:1001`) different than the host user.
    
Inspiration for solution: https://jtreminio.com/blog/running-docker-containers-as-current-host-user/

Solution: Add `ENV`s, `ARG`s for `USER_ID`, `GROUP_ID` so that host user can match his uid/gid with the one that sbtuser uses, in case none are provided, default `1001:1001` is being used. 

Maybe we can add check that `0:0` wasn't given?

WDYT?

