### PR TITLE
Fix resolving latest SBT version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,8 +42,8 @@ jobs:
         SBT_VERSION=$(
           curl -s https://dl.bintray.com/sbt/debian/Packages |
           grep -i -w 'sbt-[0-9]*\.[0-9]*\.[0-9]*\.deb' -o |
-          grep -i -w '[0-9]*\.[0-9]*\.[0-9]' -o |
-          sort | tail -n 1)
+          grep -i -w '[0-9]*\.[0-9]*\.[0-9]*' -o |
+          sort -V | tail -n 1)
         echo ::set-output name=VERSION::$SBT_VERSION
     - name: Create docker tag
       id: create_docker_tag


### PR DESCRIPTION
Latest builds couldn't resolve 1.3.10 as most recent SBT version. This commit fixes that.

1) Fix invalid regular expression in order to properly resolve double digit patch versions (like 1.3.10)
2) Add '-V' switch to 'sort' command, which will properly sort SBT versions