### PR TITLE
Add Scala 2.11.12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        scalaVersion: ['2.12.10', '2.13.1']
+        scalaVersion: ['2.11.12', '2.12.10', '2.13.1']
         javaTag: ['8u242', '11.0.6', '11.0.2-oraclelinux7', 'graalvm-ce-20.0.0-java11', 'graalvm-ce-20.0.0-java8']
         include:
           - javaTag: '8u242'


### PR DESCRIPTION
I know that Scala 2.11 hasn't been actively maintained now for several years but there are still several Scala projects using it as it is still the main Scala version for Spark so I think this will be very useful.