### PR TITLE
use new versions for debian and graalvm java8

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,15 +16,15 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        scalaVersion: ['2.11.12', '2.12.10', '2.13.2']
-        javaTag: ['8u242', '11.0.6', '11.0.2-oraclelinux7', 'graalvm-ce-20.0.0-java11', 'graalvm-ce-20.0.0-java8']
+        scalaVersion: ['2.11.12', '2.12.11', '2.13.2']
+        javaTag: ['8u252', '11.0.7', '11.0.2-oraclelinux7', 'graalvm-ce-20.0.0-java11', 'graalvm-ce-20.0.0-java8']
         include:
-          - javaTag: '8u242'
+          - javaTag: '8u252'
             dockerContext: 'debian'
-            baseImageTag: '8u242-jdk-stretch'
-          - javaTag: '11.0.6'
+            baseImageTag: '8u252-jdk-buster'
+          - javaTag: '11.0.7'
             dockerContext: 'debian'
-            baseImageTag: '11.0.6-jdk-stretch'
+            baseImageTag: '11.0.7-jdk-buster'
           - javaTag: '11.0.2-oraclelinux7'
             dockerContext: 'oracle'
             baseImageTag: '11.0.2-jdk-oraclelinux7'
@@ -33,7 +33,7 @@ jobs:
             baseImageTag: '20.0.0-java11'
           - javaTag: 'graalvm-ce-20.0.0-java8'
             dockerContext: 'graalvm-ce'
-            baseImageTag: '19.3.0-java8'
+            baseImageTag: '20.0.0-java8'
     steps:
     - uses: actions/checkout@v1
     - name: Get latest SBT version


### PR DESCRIPTION
Your images are truly useful, thank you for the hard work. Here's a PR that updates the debian version to the latest one and uses the graalvm 20.0.0 for java8