### PR TITLE
install rpm package

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -24,7 +24,8 @@ RUN \
   dpkg -i sbt-$SBT_VERSION.deb && \
   rm sbt-$SBT_VERSION.deb && \
   apt-get update && \
-  apt-get install sbt
+  apt-get install sbt && \
+  apt-get install rpm
 
 # Install Scala
 ## Piping curl directly in tar

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -24,8 +24,7 @@ RUN \
   dpkg -i sbt-$SBT_VERSION.deb && \
   rm sbt-$SBT_VERSION.deb && \
   apt-get update && \
-  apt-get install sbt && \
-  apt-get install rpm
+  apt-get install sbt rpm -y
 
 # Install Scala
 ## Piping curl directly in tar


### PR DESCRIPTION
sbt-native-packager allows to build rpm packages to install on readhat based distros. Would be nice to have this option.