### PR TITLE
15.0.1-jdk-buster

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       matrix:
         scalaVersion: ['2.11.12', '2.12.12', '2.13.4']
-        javaTag: ['8u265', '11.0.8', '11.0.2-oraclelinux7', 'graalvm-ce-20.0.0-java11', 'graalvm-ce-20.0.0-java8']
+        javaTag: ['8u265', '11.0.8', '15.0.1', '11.0.2-oraclelinux7', 'graalvm-ce-20.0.0-java11', 'graalvm-ce-20.0.0-java8']
         include:
           - javaTag: '8u265'
             dockerContext: 'debian'
@@ -25,6 +25,9 @@ jobs:
           - javaTag: '11.0.8'
             dockerContext: 'debian'
             baseImageTag: '11.0.8-jdk-buster'
+          - javaTag: '15.0.1'
+            dockerContext: 'debian'
+            baseImageTag: '15.0.1-jdk-buster'
           - javaTag: '11.0.2-oraclelinux7'
             dockerContext: 'oracle'
             baseImageTag: '11.0.2-jdk-oraclelinux7'


### PR DESCRIPTION
For ppl that want to live on the edge, I suggest we only keep the latest non-lts (which might have scala compatibility issues?)

https://docs.scala-lang.org/overviews/jdk-compatibility/overview.html

We could drop Scala `2.11.x` for this build but I think it's ok to let the user decide what he wants to use

fixes #118