### PR TITLE
Update JDK versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,18 +16,18 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        scalaVersion: ['2.11.12', '2.12.12', '2.13.4']
-        javaTag: ['8u265', '11.0.9.1', '15.0.1', '11.0.2-oraclelinux7', ]
+        scalaVersion: ['2.11.12', '2.12.13', '2.13.4']
+        javaTag: ['8u282', '11.0.10', '15.0.2', '11.0.2-oraclelinux7', ]
         include:
-          - javaTag: '8u265'
+          - javaTag: '8u282'
             dockerContext: 'debian'
-            baseImageTag: '8u265-jdk-buster'
-          - javaTag: '11.0.9.1'
+            baseImageTag: '8u282-jdk-buster'
+          - javaTag: '11.0.10'
             dockerContext: 'debian'
-            baseImageTag: '11.0.9.1-jdk-buster'
-          - javaTag: '15.0.1'
+            baseImageTag: '11.0.10-jdk-buster'
+          - javaTag: '15.0.2'
             dockerContext: 'debian'
-            baseImageTag: '15.0.1-jdk-buster'
+            baseImageTag: '15.0.2-jdk-buster'
           - javaTag: '11.0.2-oraclelinux7'
             dockerContext: 'oracle'
             baseImageTag: '11.0.2-jdk-oraclelinux7'


### PR DESCRIPTION
New JDKs are released including security fix, see:
https://mail.openjdk.java.net/pipermail/jdk8u-dev/2021-January/013337.html
https://mail.openjdk.java.net/pipermail/jdk-updates-dev/2021-January/004689.html

Also update Scala 2.12 version