### PR TITLE
Temporary fix for missing .ivy2 directory

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -72,6 +72,8 @@ RUN \
 # This allows users of this container to choose, whether they want to run the container as sbtuser (non-root) or as root
 USER root
 RUN \
+  mkdir -p /home/sbtuser/.ivy2 && \
+  chown -R sbtuser:sbtuser /home/sbtuser/.ivy2 && \
   ln -s /home/sbtuser/.cache /root/.cache && \
   ln -s /home/sbtuser/.ivy2 /root/.ivy2 && \
   ln -s /home/sbtuser/.sbt /root/.sbt

--- a/graalvm-ce/Dockerfile
+++ b/graalvm-ce/Dockerfile
@@ -68,6 +68,8 @@ RUN \
 # This allows users of this container to choose, whether they want to run the container as sbtuser (non-root) or as root
 USER root
 RUN \
+  mkdir -p /home/sbtuser/.ivy2 && \
+  chown -R sbtuser:sbtuser /home/sbtuser/.ivy2 && \
   ln -s /home/sbtuser/.cache /root/.cache && \
   ln -s /home/sbtuser/.ivy2 /root/.ivy2 && \
   ln -s /home/sbtuser/.sbt /root/.sbt

--- a/oracle/Dockerfile
+++ b/oracle/Dockerfile
@@ -70,7 +70,7 @@ RUN \
 # This allows users of this container to choose, whether they want to run the container as sbtuser (non-root) or as root
 USER root
 RUN \
-  mkdir /home/sbtuser/.ivy2 && \
+  mkdir -p /home/sbtuser/.ivy2 && \
   chown -R sbtuser:sbtuser /home/sbtuser/.ivy2 && \
   ln -s /home/sbtuser/.cache /root/.cache && \
   ln -s /home/sbtuser/.ivy2 /root/.ivy2 && \

--- a/oracle/Dockerfile
+++ b/oracle/Dockerfile
@@ -18,6 +18,9 @@ ENV USER_ID ${USER_ID:-1001}
 ARG GROUP_ID 
 ENV GROUP_ID ${GROUP_ID:-1001}
 
+# Install git because it's very useful to have that should the version be extracted from git
+RUN microdnf install git
+
 # Install findutils since find is required for scala 3
 RUN microdnf install findutils
 

--- a/oracle/Dockerfile
+++ b/oracle/Dockerfile
@@ -6,7 +6,7 @@
 
 # Pull base image
 ARG BASE_IMAGE_TAG
-FROM openjdk:${BASE_IMAGE_TAG:-11.0.10-jdk-oraclelinux8}
+FROM openjdk:${BASE_IMAGE_TAG:-16-jdk-oraclelinux8}
 
 # Env variables
 ARG SCALA_VERSION
@@ -70,6 +70,8 @@ RUN \
 # This allows users of this container to choose, whether they want to run the container as sbtuser (non-root) or as root
 USER root
 RUN \
+  mkdir /home/sbtuser/.ivy2 && \
+  chown -R sbtuser:sbtuser /home/sbtuser/.ivy2 && \
   ln -s /home/sbtuser/.cache /root/.cache && \
   ln -s /home/sbtuser/.ivy2 /root/.ivy2 && \
   ln -s /home/sbtuser/.sbt /root/.sbt

--- a/oracle/Dockerfile
+++ b/oracle/Dockerfile
@@ -6,7 +6,7 @@
 
 # Pull base image
 ARG BASE_IMAGE_TAG
-FROM openjdk:${BASE_IMAGE_TAG:-16-jdk-oraclelinux8}
+FROM openjdk:${BASE_IMAGE_TAG:-11.0.10-jdk-oraclelinux8}
 
 # Env variables
 ARG SCALA_VERSION
@@ -17,9 +17,6 @@ ARG USER_ID
 ENV USER_ID ${USER_ID:-1001}
 ARG GROUP_ID 
 ENV GROUP_ID ${GROUP_ID:-1001}
-
-# Install git because it's very useful to have that should the version be extracted from git
-RUN microdnf install git
 
 # Install findutils since find is required for scala 3
 RUN microdnf install findutils


### PR DESCRIPTION
Somehow the .ivy2 directory went missing since the 1.5.0 build.

Also added git since it's not part of the oraclelinux base image anymore.