### PR TITLE
Fix pushing of images in github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,4 +95,4 @@ jobs:
       if: github.event_name != 'pull_request'
       run: |
         echo "${{ secrets.DOCKER_PASSWORD }}" | docker login -u hseeberger --password-stdin
-        docker buildx push ${{ steps.create_docker_tag.outputs.TAG }}
+        docker push ${{ steps.create_docker_tag.outputs.TAG }}


### PR DESCRIPTION
there is no `docker buildx push` which I added in in #163 

(however it does not fail, see https://github.com/docker/buildx/issues/732)