### PR TITLE
Include 'compiler-bridge_2.12' module compilation to warm up step

### DIFF
--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -61,6 +61,7 @@ RUN \
   mkdir -p project && \
   echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \
   echo "sbt.version=${SBT_VERSION}" > project/build.properties && \
+  touch project/Dependencies.scala && \
   echo "case object Temp" > Temp.scala && \
   sbt compile && \
   rm -r project && rm build.sbt && rm Temp.scala && rm -r target

--- a/debian/Dockerfile
+++ b/debian/Dockerfile
@@ -61,7 +61,7 @@ RUN \
   mkdir -p project && \
   echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \
   echo "sbt.version=${SBT_VERSION}" > project/build.properties && \
-  touch project/Dependencies.scala && \
+  echo "// force sbt compiler-bridge download" > project/Dependencies.scala && \
   echo "case object Temp" > Temp.scala && \
   sbt compile && \
   rm -r project && rm build.sbt && rm Temp.scala && rm -r target

--- a/graalvm-ce/Dockerfile
+++ b/graalvm-ce/Dockerfile
@@ -57,7 +57,7 @@ RUN \
   mkdir -p project && \
   echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \
   echo "sbt.version=${SBT_VERSION}" > project/build.properties && \
-  touch project/Dependencies.scala && \
+  echo "// force sbt compiler-bridge download" > project/Dependencies.scala && \
   echo "case object Temp" > Temp.scala && \
   sbt compile && \
   rm -r project && rm build.sbt && rm Temp.scala && rm -r target

--- a/graalvm-ce/Dockerfile
+++ b/graalvm-ce/Dockerfile
@@ -57,6 +57,7 @@ RUN \
   mkdir -p project && \
   echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \
   echo "sbt.version=${SBT_VERSION}" > project/build.properties && \
+  touch project/Dependencies.scala && \
   echo "case object Temp" > Temp.scala && \
   sbt compile && \
   rm -r project && rm build.sbt && rm Temp.scala && rm -r target

--- a/oracle/Dockerfile
+++ b/oracle/Dockerfile
@@ -56,6 +56,7 @@ RUN \
   mkdir -p project && \
   echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \
   echo "sbt.version=${SBT_VERSION}" > project/build.properties && \
+  touch project/Dependencies.scala && \
   echo "case object Temp" > Temp.scala && \
   sbt compile && \
   rm -r project && rm build.sbt && rm Temp.scala && rm -r target

--- a/oracle/Dockerfile
+++ b/oracle/Dockerfile
@@ -56,7 +56,7 @@ RUN \
   mkdir -p project && \
   echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \
   echo "sbt.version=${SBT_VERSION}" > project/build.properties && \
-  touch project/Dependencies.scala && \
+  echo "// force sbt compiler-bridge download" > project/Dependencies.scala && \
   echo "case object Temp" > Temp.scala && \
   sbt compile && \
   rm -r project && rm build.sbt && rm Temp.scala && rm -r target


### PR DESCRIPTION
Example of output during `docker build` command:

```
[info] compiling 1 Scala source to /home/sbtuser/project/target/scala-2.12/sbt-1.0/classes ...
[info] Non-compiled module 'compiler-bridge_2.12' for Scala 2.12.14. Compiling...
[info]   Compilation completed in 7.163s.
[info] done compiling
```