### PR TITLE
install git in eclipse-temurin build

### DIFF
--- a/eclipse-temurin/Dockerfile
+++ b/eclipse-temurin/Dockerfile
@@ -42,9 +42,10 @@ RUN \
   esac && \
   scala -nocompdaemon test.scala && rm test.scala
 
-# Install rpm for sbt-native-packager
-# see https://github.com/hseeberger/scala-sbt/pull/114
-RUN apt-get update && \
+# Install git and rpm for sbt-native-packager (see https://github.com/hseeberger/scala-sbt/pull/114)
+RUN \
+  apt-get update && \
+  apt-get install git -y && \
   apt-get install rpm -y && \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Currently, the eclipse-temurin variant doesn't have git installed by default (Ubuntu 20.04.3).

However, it is installed in other variants as it's helpful if your builds use for example https://github.com/dwijnand/sbt-dynver

