### PR TITLE
Fix link to tag page

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains **Dockerfile** of [Scala](http://www.scala-lang.org) an
 
 As we think referencing unstable versions is a bad idea we don't publish a `latest` tag
 
-For a list of all available tags see https://hub.docker.com/repository/docker/sbtscala/scala-sbt/tags
+For a list of all available tags see https://hub.docker.com/r/sbtscala/scala-sbt/tags
 
 Older tags are available at: https://hub.docker.com/r/hseeberger/scala-sbt/tags
 


### PR DESCRIPTION
The current link is private. 
https://hub.docker.com/r/sbtscala/scala-sbt/tags is available publicly.