### PR TITLE
Updated eclipse-temurin@21 to 21.0.8_9

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,10 @@ jobs:
           'graalvm-community-21.0.2',
           'graalvm-ce-22.3.3-b1-java17',
           'eclipse-temurin-24.0.1_9',
-          'eclipse-temurin-21.0.7_6',
+          'eclipse-temurin-21.0.8_9',
           'eclipse-temurin-17.0.15_6',
           'eclipse-temurin-alpine-24.0.1_9',
-          'eclipse-temurin-alpine-21.0.7_6',
+          'eclipse-temurin-alpine-21.0.8_9',
           'eclipse-temurin-alpine-17.0.15_6',
           'amazoncorretto-al2023-21.0.8',
           'amazoncorretto-al2023-17.0.16'
@@ -51,9 +51,9 @@ jobs:
             dockerContext: 'eclipse-temurin'
             baseImageTag: '24.0.1_9-jdk'
             platforms: 'linux/amd64,linux/arm64'
-          - javaTag: 'eclipse-temurin-21.0.7_6'
+          - javaTag: 'eclipse-temurin-21.0.8_9'
             dockerContext: 'eclipse-temurin'
-            baseImageTag: '21.0.7_6-jdk'
+            baseImageTag: '21.0.8_9-jdk'
             platforms: 'linux/amd64,linux/arm64'
           - javaTag: 'eclipse-temurin-17.0.15_6'
             dockerContext: 'eclipse-temurin'
@@ -65,10 +65,10 @@ jobs:
             dockerfile: 'alpine.Dockerfile'
             baseImageTag: '24.0.1_9-jdk-alpine'
             platforms: 'linux/amd64,linux/arm64/v8'
-          - javaTag: 'eclipse-temurin-alpine-21.0.7_6'
+          - javaTag: 'eclipse-temurin-alpine-21.0.8_9'
             dockerContext: 'eclipse-temurin'
             dockerfile: 'alpine.Dockerfile'
-            baseImageTag: '21.0.7_6-jdk-alpine'
+            baseImageTag: '21.0.8_9-jdk-alpine'
             platforms: 'linux/amd64,linux/arm64/v8'
           - javaTag: 'eclipse-temurin-alpine-17.0.15_6'
             dockerContext: 'eclipse-temurin'


### PR DESCRIPTION
From `21.0.7_6` to `21.0.8_9`

- https://hub.docker.com/layers/library/eclipse-temurin/21.0.8_9-jdk/images/sha256-4b66aea1b768f33895129eb56ee3668f7e37caba22c53c71a95fcace1f794136
- https://hub.docker.com/layers/library/eclipse-temurin/21.0.8_9-jdk-alpine/images/sha256-7aaf145ac1b4cac2cebce48828e6e7da4039eb3d0b49130533faaf4df104160c