### PR TITLE
Performed minor update on amazon corretto dockerfile

### DIFF
--- a/amazoncorretto/Dockerfile
+++ b/amazoncorretto/Dockerfile
@@ -63,7 +63,7 @@ WORKDIR /home/sbtuser
 
 # Prepare sbt (warm cache)
 RUN \
-  sbt --script-version && \
+  sbt --script-version || sbt about && \
   mkdir -p project && \
   echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \
   echo "sbt.version=${SBT_VERSION}" > project/build.properties && \


### PR DESCRIPTION
docker build command was failing:

docker build \
  --build-arg BASE_IMAGE_TAG="11.0.29-al2023" \
  --build-arg SBT_VERSION="1.2.8" \
  --build-arg SCALA_VERSION="2.12.6" \
  --build-arg USER_ID=1001 \
  --build-arg GROUP_ID=1001 \
  -t sbtscala/scala-sbt \
  "github.com/sbt/docker-sbt.git#:amazoncorretto"
  
  Due to sbt --script-version is not available. Performed update on dockerfile in order to allow sbt command to go through for earlier versions of sbt
  
  sbt --script-version || sbt about
  