### PR TITLE
Build eclipse-temurin on native runners

### DIFF
--- a/.github/images.yml
+++ b/.github/images.yml
@@ -1,0 +1,62 @@
+# Build matrix data for the eclipse-temurin images, consumed by the native-runner
+# pipeline in .github/workflows/build-temurin.yml.
+#
+# Line shapes intentionally match the matrix in build.yml so the same Renovate
+# managers track them (see .github/renovate.json). During the Option 2 rollout
+# SBT_VERSION and scalaVersion are still also defined in build.yml for the
+# not-yet-migrated variants; Renovate keeps the copies in sync.
+
+# renovate: datasource=github-releases depName=sbt/sbt extractVersion=^v(?<version>.+)$
+SBT_VERSION: '1.12.11'
+
+scalaVersion:
+  # renovate: datasource=github-releases depName=scala/scala extractVersion=^v(?<version>.+)$ versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
+  - '2.12.21'
+  # renovate: datasource=github-releases depName=scala/scala extractVersion=^v(?<version>.+)$ versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
+  - '2.13.18'
+  # renovate: datasource=github-releases depName=scala/scala3 versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
+  - '3.3.7'
+  # renovate: datasource=github-releases depName=scala/scala3 versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
+  - '3.8.4'
+
+# eclipse-temurin base images. `platforms` (comma separated) drives the per-arch
+# native build fan-out; the public "<java>" tag label is derived from baseImageTag.
+javaImage:
+  # https://hub.docker.com/_/eclipse-temurin/tags
+  # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk$
+  - dockerContext: 'eclipse-temurin'
+    baseImageTag: '25.0.1_8-jdk'
+    platforms: 'linux/amd64,linux/arm64'
+  # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk$
+  - dockerContext: 'eclipse-temurin'
+    baseImageTag: '24.0.1_9-jdk'
+    platforms: 'linux/amd64,linux/arm64'
+  # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk$
+  - dockerContext: 'eclipse-temurin'
+    baseImageTag: '21.0.8_9-jdk'
+    platforms: 'linux/amd64,linux/arm64'
+  # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk$
+  - dockerContext: 'eclipse-temurin'
+    baseImageTag: '17.0.15_6-jdk'
+    platforms: 'linux/amd64,linux/arm64'
+  # https://hub.docker.com/_/eclipse-temurin/tags?page=1&name=alpine
+  # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk-alpine$
+  - dockerContext: 'eclipse-temurin'
+    dockerfile: 'alpine.Dockerfile'
+    baseImageTag: '25.0.1_8-jdk-alpine'
+    platforms: 'linux/amd64,linux/arm64/v8'
+  # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk-alpine$
+  - dockerContext: 'eclipse-temurin'
+    dockerfile: 'alpine.Dockerfile'
+    baseImageTag: '24.0.1_9-jdk-alpine'
+    platforms: 'linux/amd64,linux/arm64/v8'
+  # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk-alpine$
+  - dockerContext: 'eclipse-temurin'
+    dockerfile: 'alpine.Dockerfile'
+    baseImageTag: '21.0.8_9-jdk-alpine'
+    platforms: 'linux/amd64,linux/arm64/v8'
+  # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk-alpine$
+  - dockerContext: 'eclipse-temurin'
+    dockerfile: 'alpine.Dockerfile'
+    baseImageTag: '17.0.15_6-jdk-alpine'
+    platforms: 'linux/amd64'

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -20,7 +20,8 @@
       "customType": "regex",
       "description": "JDK base images in the build matrix (one entry per `# renovate:` comment)",
       "managerFilePatterns": [
-        "/^\\.github/workflows/build\\.yml$/"
+        "/^\\.github/workflows/build\\.yml$/",
+        "/^\\.github/images\\.yml$/"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?\\s+- dockerContext: '[^']+'(?:\\s+dockerfile: '[^']+')?\\s+baseImageTag: '(?<currentValue>[^']+)'"
@@ -30,7 +31,8 @@
       "customType": "regex",
       "description": "Scala versions in the build matrix (one entry per `# renovate:` comment)",
       "managerFilePatterns": [
-        "/^\\.github/workflows/build\\.yml$/"
+        "/^\\.github/workflows/build\\.yml$/",
+        "/^\\.github/images\\.yml$/"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?(?: versioning=(?<versioning>\\S+))?\\s+- '(?<currentValue>[^']+)'"
@@ -40,7 +42,8 @@
       "customType": "regex",
       "description": "sbt version baked into every image (SBT_VERSION env var)",
       "managerFilePatterns": [
-        "/^\\.github/workflows/build\\.yml$/"
+        "/^\\.github/workflows/build\\.yml$/",
+        "/^\\.github/images\\.yml$/"
       ],
       "matchStrings": [
         "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: extractVersion=(?<extractVersion>\\S+))?(?: versioning=(?<versioning>\\S+))?\\s+SBT_VERSION: '(?<currentValue>[^']+)'"

--- a/.github/workflows/build-temurin.yml
+++ b/.github/workflows/build-temurin.yml
@@ -1,0 +1,182 @@
+name: Build eclipse-temurin
+
+# prepare -> build (one job per arch on a native runner: test + push by digest)
+#         -> merge  (assemble the multi-arch tag from the per-arch digests)
+#
+# Each architecture is built exactly once on its own native runner (no QEMU),
+# tested there, and only then assembled into the published multi-arch tag. A
+# failing arch fails in isolation (fail-fast: false): every tag whose
+# architectures all built is still pushed. An incomplete tag fails its merge
+# job (red) instead of publishing half-built, so a transient failure can be
+# recovered with "Re-run failed jobs".
+#
+# Only eclipse-temurin is built here; the other variants are built by build.yml.
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+  schedule:
+    - cron: '0 0 * * *'
+
+env:
+  IMAGE: sbtscala/scala-sbt
+
+jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      build: ${{ steps.gen.outputs.build }}
+      merge: ${{ steps.gen.outputs.merge }}
+    steps:
+    - uses: actions/checkout@v6
+    - name: Generate build and merge matrices
+      id: gen
+      run: |
+        data=$(yq -o=json '.' .github/images.yml)
+        # build matrix: one job per scala x image x platform (native runner per arch)
+        build=$(echo "$data" | jq -c '
+          . as $root
+          | [ $root.scalaVersion[] as $scala
+              | $root.javaImage[] as $img
+              | ($img.platforms | split(",")[]) as $platform
+              | {
+                  scala: $scala,
+                  context: $img.dockerContext,
+                  dockerfile: ($img.dockerfile // "Dockerfile"),
+                  baseImageTag: $img.baseImageTag,
+                  label: ("eclipse-temurin-" + (if ($img.baseImageTag | endswith("-jdk-alpine")) then "alpine-" + ($img.baseImageTag | sub("-jdk-alpine$";"")) else ($img.baseImageTag | sub("-jdk$";"")) end)),
+                  platform: $platform,
+                  platformId: ($platform | sub("^linux/";"") | gsub("/";"-")),
+                  runner: (if ($platform | startswith("linux/arm64")) then "ubuntu-24.04-arm" else "ubuntu-24.04" end),
+                  sbt: $root.SBT_VERSION
+                } ]')
+        # merge matrix: one job per final tag (scala x image)
+        merge=$(echo "$data" | jq -c '
+          . as $root
+          | [ $root.scalaVersion[] as $scala
+              | $root.javaImage[] as $img
+              | {
+                  scala: $scala,
+                  label: ("eclipse-temurin-" + (if ($img.baseImageTag | endswith("-jdk-alpine")) then "alpine-" + ($img.baseImageTag | sub("-jdk-alpine$";"")) else ($img.baseImageTag | sub("-jdk$";"")) end)),
+                  platformCount: ($img.platforms | split(",") | length),
+                  sbt: $root.SBT_VERSION
+                } ]')
+        echo "build={\"include\":$build}" >> "$GITHUB_OUTPUT"
+        echo "merge={\"include\":$merge}" >> "$GITHUB_OUTPUT"
+    - name: Show matrices
+      run: |
+        echo '${{ steps.gen.outputs.build }}' | jq '.include | length as $n | "build jobs: \($n)"'
+        echo '${{ steps.gen.outputs.merge }}' | jq '.include | length as $n | "merge jobs (tags): \($n)"'
+
+  build:
+    needs: prepare
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.build) }}
+    steps:
+    - uses: actions/checkout@v6
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4.1.0
+    - name: Build and load for testing (${{ matrix.platform }})
+      uses: docker/build-push-action@v7
+      with:
+        context: ${{ matrix.context }}
+        file: ${{ matrix.context }}/${{ matrix.dockerfile }}
+        platforms: ${{ matrix.platform }}
+        no-cache: true
+        load: true
+        tags: scala-sbt:test
+        build-args: |
+          BASE_IMAGE_TAG=${{ matrix.baseImageTag }}
+          SBT_VERSION=${{ matrix.sbt }}
+          SCALA_VERSION=${{ matrix.scala }}
+        cache-to: type=gha,mode=max,scope=${{ matrix.label }}-${{ matrix.scala }}-${{ matrix.platformId }}
+    - name: Test image as root (default)
+      if: ${{ !startsWith(matrix.scala, '2.12') }}
+      # scala --version does not work on < 2.13
+      run: docker run --rm scala-sbt:test /bin/bash -c "scala --version && sbt --script-version"
+    - name: Test image scala as sbtuser
+      if: ${{ !startsWith(matrix.scala, '2.12') }}
+      run: docker run --rm -u sbtuser -w /home/sbtuser scala-sbt:test /bin/bash -c "scala --version && sbt --script-version"
+    - name: Log in to DockerHub
+      if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push by digest (${{ matrix.platform }})
+      id: push
+      if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
+      uses: docker/build-push-action@v7
+      with:
+        context: ${{ matrix.context }}
+        file: ${{ matrix.context }}/${{ matrix.dockerfile }}
+        platforms: ${{ matrix.platform }}
+        # Reuses the layers just built for the test above (same run, same scope),
+        # so this does not rebuild from scratch.
+        cache-from: type=gha,scope=${{ matrix.label }}-${{ matrix.scala }}-${{ matrix.platformId }}
+        build-args: |
+          BASE_IMAGE_TAG=${{ matrix.baseImageTag }}
+          SBT_VERSION=${{ matrix.sbt }}
+          SCALA_VERSION=${{ matrix.scala }}
+        outputs: type=image,name=${{ env.IMAGE }},push-by-digest=true,name-canonical=true,push=true
+    - name: Export digest
+      if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
+      run: |
+        mkdir -p /tmp/digests
+        digest="${{ steps.push.outputs.digest }}"
+        touch "/tmp/digests/${digest#sha256:}"
+    - name: Upload digest
+      if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: digest-${{ matrix.label }}_${{ matrix.scala }}-${{ matrix.platformId }}
+        path: /tmp/digests/*
+        if-no-files-found: error
+        retention-days: 1
+
+  merge:
+    needs: [prepare, build]
+    # Run even when some build jobs failed, so every tag whose architectures all
+    # built still gets pushed. Only require prepare (for the matrix) to succeed.
+    if: ${{ !cancelled() && needs.prepare.result == 'success' && github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{ fromJSON(needs.prepare.outputs.merge) }}
+    steps:
+    - name: Download digests for ${{ matrix.label }} / scala ${{ matrix.scala }}
+      uses: actions/download-artifact@v4
+      with:
+        path: /tmp/digests
+        pattern: digest-${{ matrix.label }}_${{ matrix.scala }}-*
+        merge-multiple: true
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4.1.0
+    - name: Log in to DockerHub
+      uses: docker/login-action@v4
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Create and push multi-arch manifest
+      working-directory: /tmp/digests
+      run: |
+        shopt -s nullglob
+        tag="${IMAGE}:${{ matrix.label }}_${{ matrix.sbt }}_${{ matrix.scala }}"
+        digests=( * )
+        expected=${{ matrix.platformCount }}
+        # Fail (rather than silently skip) when not all architectures are present,
+        # so a transient build failure can be recovered with "Re-run failed jobs":
+        # the failed build re-uploads its digest and this job re-runs to push it.
+        # fail-fast: false keeps this from affecting the other tags.
+        if [ "${#digests[@]}" -ne "$expected" ]; then
+          echo "::error title=Incomplete::${#digests[@]}/${expected} architectures available for ${tag}; not publishing. Re-run the failed build job(s) then this job to recover."
+          exit 1
+        fi
+        docker buildx imagetools create -t "$tag" "${digests[@]/#/${IMAGE}@sha256:}"
+        docker buildx imagetools inspect "$tag"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,44 +52,8 @@ jobs:
           - dockerContext: 'graalvm-ce'
             baseImageTag: 'ol9-java17-22.3.3-b1'
             platforms: 'linux/amd64,linux/arm64'
-          # https://hub.docker.com/_/eclipse-temurin/tags
-          # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk$
-          - dockerContext: 'eclipse-temurin'
-            baseImageTag: '25.0.1_8-jdk'
-            platforms: 'linux/amd64,linux/arm64'
-          # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk$
-          - dockerContext: 'eclipse-temurin'
-            baseImageTag: '24.0.1_9-jdk'
-            platforms: 'linux/amd64,linux/arm64'
-          # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk$
-          - dockerContext: 'eclipse-temurin'
-            baseImageTag: '21.0.8_9-jdk'
-            platforms: 'linux/amd64,linux/arm64'
-          # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk$
-          - dockerContext: 'eclipse-temurin'
-            baseImageTag: '17.0.15_6-jdk'
-            platforms: 'linux/amd64,linux/arm64'
-          # https://hub.docker.com/_/eclipse-temurin/tags?page=1&name=alpine
-          # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk-alpine$
-          - dockerContext: 'eclipse-temurin'
-            dockerfile: 'alpine.Dockerfile'
-            baseImageTag: '25.0.1_8-jdk-alpine'
-            platforms: 'linux/amd64,linux/arm64/v8'
-          # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk-alpine$
-          - dockerContext: 'eclipse-temurin'
-            dockerfile: 'alpine.Dockerfile'
-            baseImageTag: '24.0.1_9-jdk-alpine'
-            platforms: 'linux/amd64,linux/arm64/v8'
-          # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk-alpine$
-          - dockerContext: 'eclipse-temurin'
-            dockerfile: 'alpine.Dockerfile'
-            baseImageTag: '21.0.8_9-jdk-alpine'
-            platforms: 'linux/amd64,linux/arm64/v8'
-          # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk-alpine$
-          - dockerContext: 'eclipse-temurin'
-            dockerfile: 'alpine.Dockerfile'
-            baseImageTag: '17.0.15_6-jdk-alpine'
-            platforms: 'linux/amd64'
+          # NOTE: eclipse-temurin is built by .github/workflows/build-temurin.yml
+          # (native-runner pipeline, see issue #166 / .github/images.yml).
           # https://hub.docker.com/_/amazoncorretto/tags
           # renovate: datasource=docker depName=amazoncorretto versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-al2023$
           - dockerContext: 'amazoncorretto'
@@ -154,7 +118,7 @@ jobs:
         context: ${{ matrix.javaImage.dockerContext }}
         no-cache: true
         tags: ${{ steps.create_docker_tag.outputs.TAG }}
-        file: ${{ matrix.javaImage.dockerContext }}/${{ matrix.javaImage.dockerfile || 'Dockerfile' }}
+        file: ${{ matrix.javaImage.dockerContext }}/Dockerfile
         build-args: |
           BASE_IMAGE_TAG=${{ matrix.javaImage.baseImageTag }}
           SBT_VERSION=${{ env.SBT_VERSION }}
@@ -181,7 +145,7 @@ jobs:
       uses: docker/build-push-action@v7
       with:
         context: ${{ matrix.javaImage.dockerContext }}
-        file: ${{ matrix.javaImage.dockerContext }}/${{ matrix.javaImage.dockerfile || 'Dockerfile' }}
+        file: ${{ matrix.javaImage.dockerContext }}/Dockerfile
         tags: ${{ steps.create_docker_tag.outputs.TAG }}
         build-args: |
           BASE_IMAGE_TAG=${{ matrix.javaImage.baseImageTag }}


### PR DESCRIPTION
Build each architecture once on its own native runner (no QEMU), test it there, and push by digest; a merge job then assembles the multi-arch tag. A failing architecture fails in isolation: every tag whose architectures all built is still pushed, and an incomplete tag fails its merge (so a transient failure can be recovered with "Re-run failed jobs") instead of being published half-built. Removes the redundant second build of amd64 and means arm64 is actually tested instead of only built at push time.

- images.yml: eclipse-temurin build matrix data (Renovate-tracked)
- build-temurin.yml: prepare -> build -> merge pipeline
- build.yml: eclipse-temurin moves to the new workflow
- renovate.json: also scan images.yml