### PR TITLE
Support running the image as an arbitrary user id

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,14 @@ The container is prepared to be used with a non-root user called `sbtuser`
 docker run -it --rm -u sbtuser -w /home/sbtuser sbtscala/scala-sbt:eclipse-temurin-21.0.8_9_1.12.11_3.8.4
 ```
 
+You can also run as an arbitrary user id. `HOME` is set to `/home/sbtuser`, whose
+contents are group-writable for the root group (gid 0) that an arbitrary
+`-u <uid>` belongs to by default:
+
+```
+docker run -it --rm -u 1234 -w /home/sbtuser sbtscala/scala-sbt:eclipse-temurin-21.0.8_9_1.12.11_3.8.4
+```
+
 ## Automated updates with Renovate ##
 
 Because the tags combine three independent versions (`<JDK>_<sbt>_<Scala>`),

--- a/amazoncorretto/Dockerfile
+++ b/amazoncorretto/Dockerfile
@@ -53,6 +53,13 @@ RUN ln -s /opt/java/openjdk/bin/java /usr/local/bin/java
 
 # Add and use user sbtuser
 RUN groupadd --gid $GROUP_ID sbtuser && useradd -m --gid $GROUP_ID --uid $USER_ID sbtuser --shell /bin/bash
+ENV HOME=/home/sbtuser
+# Allow running the image as an arbitrary uid (not only sbtuser): own sbtuser's
+# home by the root group (gid 0, which `docker run -u <uid>` joins by default)
+# and set the setgid bit, so files written by the warm cache below inherit gid 0;
+# with `umask 0002` there they are created group-writable (no recursive chmod,
+# which would copy the whole cache into a new layer).
+RUN mkdir -p /home/sbtuser && chown sbtuser:0 /home/sbtuser && chmod 2775 /home/sbtuser
 USER sbtuser
 
 # Switch working directory
@@ -60,6 +67,7 @@ WORKDIR /home/sbtuser
 
 # Prepare sbt (warm cache)
 RUN \
+  umask 0002 && \
   sbt --script-version && \
   mkdir -p project && \
   echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \

--- a/eclipse-temurin/Dockerfile
+++ b/eclipse-temurin/Dockerfile
@@ -54,6 +54,13 @@ RUN ln -s /opt/java/openjdk/bin/java /usr/local/bin/java
 
 # Add and use user sbtuser
 RUN groupadd --gid $GROUP_ID sbtuser && useradd -m --gid $GROUP_ID --uid $USER_ID sbtuser --shell /bin/bash
+ENV HOME=/home/sbtuser
+# Allow running the image as an arbitrary uid (not only sbtuser): own sbtuser's
+# home by the root group (gid 0, which `docker run -u <uid>` joins by default)
+# and set the setgid bit, so files written by the warm cache below inherit gid 0;
+# with `umask 0002` there they are created group-writable (no recursive chmod,
+# which would copy the whole cache into a new layer).
+RUN mkdir -p /home/sbtuser && chown sbtuser:0 /home/sbtuser && chmod 2775 /home/sbtuser
 USER sbtuser
 
 # Switch working directory
@@ -61,6 +68,7 @@ WORKDIR /home/sbtuser
 
 # Prepare sbt (warm cache)
 RUN \
+  umask 0002 && \
   sbt --script-version && \
   mkdir -p project && \
   echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \

--- a/eclipse-temurin/alpine.Dockerfile
+++ b/eclipse-temurin/alpine.Dockerfile
@@ -55,6 +55,13 @@ COPY --from=builder /usr/local/bin/sbt /usr/local/bin/sbt
 
 # Add and use user sbtuser
 RUN addgroup -g $GROUP_ID sbtuser && adduser -D -u $USER_ID -G sbtuser sbtuser
+ENV HOME=/home/sbtuser
+# Allow running the image as an arbitrary uid (not only sbtuser): own sbtuser's
+# home by the root group (gid 0, which `docker run -u <uid>` joins by default)
+# and set the setgid bit, so files written by the warm cache below inherit gid 0;
+# with `umask 0002` there they are created group-writable (no recursive chmod,
+# which would copy the whole cache into a new layer).
+RUN mkdir -p /home/sbtuser && chown sbtuser:0 /home/sbtuser && chmod 2775 /home/sbtuser
 USER sbtuser
 
 # Switch working directory
@@ -64,6 +71,7 @@ ENV PATH="/usr/share/scala/bin:${PATH}"
 
 # Prepare sbt (warm cache)
 RUN \
+  umask 0002 && \
   sbt --script-version && \
   mkdir -p project && \
   echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \

--- a/graalvm-community/Dockerfile
+++ b/graalvm-community/Dockerfile
@@ -52,6 +52,13 @@ RUN \
 
 # Add and use user sbtuser
 RUN groupadd --gid $GROUP_ID sbtuser && useradd --gid $GROUP_ID --uid $USER_ID sbtuser --shell /bin/bash
+ENV HOME=/home/sbtuser
+# Allow running the image as an arbitrary uid (not only sbtuser): own sbtuser's
+# home by the root group (gid 0, which `docker run -u <uid>` joins by default)
+# and set the setgid bit, so files written by the warm cache below inherit gid 0;
+# with `umask 0002` there they are created group-writable (no recursive chmod,
+# which would copy the whole cache into a new layer).
+RUN mkdir -p /home/sbtuser && chown sbtuser:0 /home/sbtuser && chmod 2775 /home/sbtuser
 USER sbtuser
 
 # Switch working directory
@@ -59,6 +66,7 @@ WORKDIR /home/sbtuser
 
 # Prepare sbt (warm cache)
 RUN \
+  umask 0002 && \
   sbt --script-version && \
   mkdir -p project && \
   echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \

--- a/graalvm-jdk-community/Dockerfile
+++ b/graalvm-jdk-community/Dockerfile
@@ -57,6 +57,13 @@ RUN \
 
 # Add and use user sbtuser
 RUN groupadd --gid $GROUP_ID sbtuser && useradd --gid $GROUP_ID --uid $USER_ID sbtuser --shell /bin/bash
+ENV HOME=/home/sbtuser
+# Allow running the image as an arbitrary uid (not only sbtuser): own sbtuser's
+# home by the root group (gid 0, which `docker run -u <uid>` joins by default)
+# and set the setgid bit, so files written by the warm cache below inherit gid 0;
+# with `umask 0002` there they are created group-writable (no recursive chmod,
+# which would copy the whole cache into a new layer).
+RUN mkdir -p /home/sbtuser && chown sbtuser:0 /home/sbtuser && chmod 2775 /home/sbtuser
 USER sbtuser
 
 # Switch working directory
@@ -64,6 +71,7 @@ WORKDIR /home/sbtuser
 
 # Prepare sbt (warm cache)
 RUN \
+  umask 0002 && \
   sbt --script-version && \
   mkdir -p project && \
   echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \


### PR DESCRIPTION
Running as a uid other than sbtuser (1001) failed: HOME defaulted to /, so sbt could not create temp files or ~/.sbt (issue #258).

Set HOME=/home/sbtuser and own the home by the root group (gid 0, which `docker run -u <uid>` joins by default) with the setgid bit, then build the warm cache under umask 0002 so its files are group-writable. Done in-layer so it does not copy the whole cache into a new image layer. The owner stays sbtuser, so default-root and `-u sbtuser` usage are unchanged.

Applied to all images (eclipse-temurin jdk + alpine, graalvm-community, graalvm-jdk-community, amazoncorretto), and documented in the README.

fixes #258 