### PR TITLE
Cancel superseded PR workflow runs

### DIFF
--- a/.github/workflows/build-temurin.yml
+++ b/.github/workflows/build-temurin.yml
@@ -1,5 +1,11 @@
 name: Build eclipse-temurin
 
+# Cancel a superseded in-progress run when a PR is updated by a newer push.
+# Scoped to pull_request so master/scheduled publishes are never interrupted.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 # prepare -> build (one job per arch on a native runner: test + push by digest)
 #         -> merge  (assemble the multi-arch tag from the per-arch digests)
 #

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,11 @@
 name: Build
 
+# Cancel a superseded in-progress run when a PR is updated by a newer push.
+# Scoped to pull_request so master/scheduled publishes are never interrupted.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 on:
   push:
     branches:


### PR DESCRIPTION
Add a concurrency group so that pushing a new commit to a PR cancels the now-outdated in-progress run instead of leaving both running. Scoped to pull_request events only, so master and scheduled publish runs are never interrupted mid-build.