### PR TITLE
Test that images launch as an arbitrary user id

### DIFF
--- a/.github/workflows/build-temurin.yml
+++ b/.github/workflows/build-temurin.yml
@@ -109,6 +109,9 @@ jobs:
     - name: Test image scala as sbtuser
       if: ${{ !startsWith(matrix.scala, '2.12') }}
       run: docker run --rm -u sbtuser -w /home/sbtuser scala-sbt:test /bin/bash -c "scala --version && sbt --script-version"
+    - name: Test image launches as an arbitrary uid (issue #258)
+      # full sbt launch (not --script-version) so it exercises temp/HOME writes
+      run: docker run --rm -u 1234 -w /home/sbtuser scala-sbt:test sbt --allow-empty exit
     - name: Log in to DockerHub
       if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
       uses: docker/login-action@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,6 +168,10 @@ jobs:
       # scala --version does not work on < 2.13
       run: |
         docker run -u sbtuser -w /home/sbtuser "${{ steps.create_docker_tag.outputs.TAG }}" /bin/bash -c "scala --version && sbt --script-version"
+    - name: Test docker image launches as an arbitrary uid (issue #258)
+      # full sbt launch (not --script-version) so it exercises temp/HOME writes
+      run: |
+        docker run --rm -u 1234 -w /home/sbtuser "${{ steps.create_docker_tag.outputs.TAG }}" sbt --allow-empty exit
     - name: Log in to DockerHub
       if: github.event_name != 'pull_request' && github.actor != 'dependabot[bot]'
       uses: docker/login-action@v4


### PR DESCRIPTION
Add a test step that runs `sbt exit` as a non-sbtuser uid (1234), verifying the arbitrary-uid support added in #258. Uses a full sbt launch rather than --script-version so it actually exercises the temp-file/HOME writes that previously failed. Runs unconditionally, so it also covers the Scala 2.12 images (which skip the scala-based tests).
