### PR TITLE
Remove the bundled scala CLI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,12 +119,9 @@ jobs:
           SCALA_VERSION=${{ matrix.scala }}
         cache-to: type=gha,mode=max,scope=${{ matrix.label }}-${{ matrix.sbt }}-${{ matrix.scala }}-${{ matrix.platformId }}
     - name: Test image as root (default)
-      if: ${{ !startsWith(matrix.scala, '2.12') }}
-      # scala --version does not work on < 2.13
-      run: docker run --rm scala-sbt:test /bin/bash -c "scala --version && sbt --script-version"
-    - name: Test image scala as sbtuser
-      if: ${{ !startsWith(matrix.scala, '2.12') }}
-      run: docker run --rm -u sbtuser -w /home/sbtuser scala-sbt:test /bin/bash -c "scala --version && sbt --script-version"
+      run: docker run --rm scala-sbt:test sbt --script-version
+    - name: Test image as sbtuser
+      run: docker run --rm -u sbtuser -w /home/sbtuser scala-sbt:test sbt --script-version
     - name: Test image launches as an arbitrary uid (issue #258)
       # write a build file (also checks the home dir is writable) then fully
       # launch sbt, which exercises the temp/HOME writes that previously failed

--- a/README.md
+++ b/README.md
@@ -46,11 +46,16 @@ docker run -it --rm sbtscala/scala-sbt:eclipse-temurin-21.0.8_9_1.12.11_3.8.4
 ```
 
 ### Alternative commands ###
-The container contains `bash`, `scala` and `sbt`.
+The container contains `bash` and `sbt`.
 
 ```
-docker run -it --rm sbtscala/scala-sbt:eclipse-temurin-21.0.8_9_1.12.11_3.8.4 scala
+docker run -it --rm sbtscala/scala-sbt:eclipse-temurin-21.0.8_9_1.12.11_3.8.4 bash
 ```
+
+The standalone `scala` CLI is not bundled: sbt resolves its own Scala per project,
+so it was unused for sbt builds. If you want Scala without sbt (scripts, the REPL),
+use the [Scala CLI](https://github.com/VirtusLab/scala-cli) image
+[`virtuslab/scala-cli`](https://hub.docker.com/r/virtuslab/scala-cli).
 
 ### Non-root ###
 The container is prepared to be used with a non-root user called `sbtuser`

--- a/amazoncorretto/Dockerfile
+++ b/amazoncorretto/Dockerfile
@@ -32,22 +32,6 @@ RUN \
   chmod -R 755 /usr/share/sbt && \
   ln -s /usr/share/sbt/bin/sbt /usr/local/bin/sbt
 
-# Install Scala
-RUN \
-  case $SCALA_VERSION in \
-    2.*) URL=https://github.com/scala/scala/releases/download/v$SCALA_VERSION/scala-$SCALA_VERSION.tgz SCALA_DIR=/usr/share/scala-$SCALA_VERSION ;; \
-    *) URL=https://github.com/scala/scala3/releases/download/$SCALA_VERSION/scala3-$SCALA_VERSION.tar.gz SCALA_DIR=/usr/share/scala3-$SCALA_VERSION ;; \
-  esac && \
-  curl -fsL --show-error $URL | tar xfz - -C /usr/share && \
-  mv $SCALA_DIR /usr/share/scala && \
-  chown -R root:root /usr/share/scala && \
-  chmod -R 755 /usr/share/scala && \
-  ln -s /usr/share/scala/bin/* /usr/local/bin && \
-  case $SCALA_VERSION in \
-    2*) echo "println(util.Properties.versionMsg)" > test.scala && scala -nocompdaemon test.scala ;; \
-    *) echo 'import java.io.FileInputStream;import java.util.jar.JarInputStream;val scala3LibJar = classOf[CanEqual[?, ?]].getProtectionDomain.getCodeSource.getLocation.toURI.getPath;val manifest = new JarInputStream(new FileInputStream(scala3LibJar)).getManifest;val ver = manifest.getMainAttributes.getValue("Implementation-Version");@main def main = println(s"Scala version ${ver}")' > test.scala && scala --server=false test.scala ;; \
-  esac && rm test.scala
-
 # Symlink java to have it available on sbtuser's PATH
 RUN ln -s /opt/java/openjdk/bin/java /usr/local/bin/java
 

--- a/eclipse-temurin/Dockerfile
+++ b/eclipse-temurin/Dockerfile
@@ -33,22 +33,6 @@ RUN \
   chmod -R 755 /usr/share/sbt && \
   ln -s /usr/share/sbt/bin/sbt /usr/local/bin/sbt
 
-# Install Scala
-RUN \
-  case $SCALA_VERSION in \
-    2.*) URL=https://github.com/scala/scala/releases/download/v$SCALA_VERSION/scala-$SCALA_VERSION.tgz SCALA_DIR=/usr/share/scala-$SCALA_VERSION ;; \
-    *) URL=https://github.com/scala/scala3/releases/download/$SCALA_VERSION/scala3-$SCALA_VERSION.tar.gz SCALA_DIR=/usr/share/scala3-$SCALA_VERSION ;; \
-  esac && \
-  curl -fsL --show-error $URL | tar xfz - -C /usr/share/ && \
-  mv $SCALA_DIR /usr/share/scala && \
-  chown -R root:root /usr/share/scala && \
-  chmod -R 755 /usr/share/scala && \
-  ln -s /usr/share/scala/bin/* /usr/local/bin && \
-  case $SCALA_VERSION in \
-    2*) echo "println(util.Properties.versionMsg)" > test.scala && scala -nocompdaemon test.scala ;; \
-    *) echo 'import java.io.FileInputStream;import java.util.jar.JarInputStream;val scala3LibJar = classOf[CanEqual[?, ?]].getProtectionDomain.getCodeSource.getLocation.toURI.getPath;val manifest = new JarInputStream(new FileInputStream(scala3LibJar)).getManifest;val ver = manifest.getMainAttributes.getValue("Implementation-Version");@main def main = println(s"Scala version ${ver}")' > test.scala && scala --server=false test.scala ;; \
-  esac && rm test.scala
-
 # Symlink java to have it available on sbtuser's PATH
 RUN ln -s /opt/java/openjdk/bin/java /usr/local/bin/java
 

--- a/eclipse-temurin/alpine.Dockerfile
+++ b/eclipse-temurin/alpine.Dockerfile
@@ -1,6 +1,6 @@
 # Use a multi-stage build to reduce the size of the final image
-# The builder will install curl, bc and ca-certificates which are needed to install sbt and scala.
-# The final image will only contain bash, git, rpm, sbt and scala.
+# The builder will install curl, bc and ca-certificates which are needed to install sbt.
+# The final image will only contain bash, git, rpm and sbt.
 
 ARG BASE_IMAGE_TAG
 FROM eclipse-temurin:${BASE_IMAGE_TAG:-21.0.2_13-jdk-alpine} AS builder
@@ -9,7 +9,6 @@ ARG SCALA_VERSION=3.4.0
 ARG SBT_VERSION=1.10.7
 ARG USER_ID=1001
 ARG GROUP_ID=1001
-ENV SCALA_HOME=/usr/share/scala
 
 # Install dependencies
 RUN apk add wget ca-certificates bash curl bc
@@ -23,22 +22,6 @@ RUN \
     ln -s /usr/local/sbt/bin/* /usr/local/bin/ && \
     sbt --script-version
 
-# Install scala
-RUN \
-  cd "/tmp" && \
-  case $SCALA_VERSION in \
-    2.*) URL=https://github.com/scala/scala/releases/download/v$SCALA_VERSION/scala-$SCALA_VERSION.tgz SCALA_DIR=/usr/share/scala-$SCALA_VERSION ;; \
-    *) URL=https://github.com/scala/scala3/releases/download/$SCALA_VERSION/scala3-$SCALA_VERSION.tar.gz SCALA_DIR=/usr/share/scala3-$SCALA_VERSION ;; \
-  esac && \
-  curl -fsL --show-error $URL | tar xfz - -C /usr/share && \
-  mv $SCALA_DIR $SCALA_HOME && \
-  ln -s "$SCALA_HOME/bin/"* "/usr/bin/" && \
-  scala -version && \
-  case $SCALA_VERSION in \
-    2*) echo "println(util.Properties.versionMsg)" > test.scala && scala -nocompdaemon test.scala ;; \
-    *) echo 'import java.io.FileInputStream;import java.util.jar.JarInputStream;val scala3LibJar = classOf[CanEqual[?, ?]].getProtectionDomain.getCodeSource.getLocation.toURI.getPath;val manifest = new JarInputStream(new FileInputStream(scala3LibJar)).getManifest;val ver = manifest.getMainAttributes.getValue("Implementation-Version");@main def main = println(s"Scala version ${ver}")' > test.scala && scala --server=false test.scala ;; \
-  esac && rm test.scala
-
 # Start a new stage for the final image
 FROM eclipse-temurin:${BASE_IMAGE_TAG:-21.0.2_13-jdk-alpine}
 
@@ -49,7 +32,6 @@ ARG GROUP_ID=1001
 
 RUN apk add --no-cache bash git rpm
 
-COPY --from=builder /usr/share/scala /usr/share/scala
 COPY --from=builder /usr/local/sbt /usr/local/sbt
 COPY --from=builder /usr/local/bin/sbt /usr/local/bin/sbt
 
@@ -66,8 +48,6 @@ USER sbtuser
 
 # Switch working directory
 WORKDIR /home/sbtuser
-
-ENV PATH="/usr/share/scala/bin:${PATH}"
 
 # Prepare sbt (warm cache)
 RUN \

--- a/graalvm-community/Dockerfile
+++ b/graalvm-community/Dockerfile
@@ -34,22 +34,6 @@ RUN \
   chmod -R 755 /usr/share/sbt && \
   ln -s /usr/share/sbt/bin/sbt /usr/local/bin/sbt
 
-# Install Scala
-RUN \
-  case $SCALA_VERSION in \
-    2.*) URL=https://github.com/scala/scala/releases/download/v$SCALA_VERSION/scala-$SCALA_VERSION.tgz SCALA_DIR=/usr/share/scala-$SCALA_VERSION ;; \
-    *) URL=https://github.com/scala/scala3/releases/download/$SCALA_VERSION/scala3-$SCALA_VERSION.tar.gz SCALA_DIR=/usr/share/scala3-$SCALA_VERSION ;; \
-  esac && \
-  curl -fsL --show-error $URL | tar xfz - -C /usr/share && \
-  mv $SCALA_DIR /usr/share/scala && \
-  chown -R root:root /usr/share/scala && \
-  chmod -R 755 /usr/share/scala && \
-  ln -s /usr/share/scala/bin/* /usr/local/bin && \
-  case $SCALA_VERSION in \
-    2*) echo "println(util.Properties.versionMsg)" > test.scala && scala -nocompdaemon test.scala ;; \
-    *) echo 'import java.io.FileInputStream;import java.util.jar.JarInputStream;val scala3LibJar = classOf[CanEqual[?, ?]].getProtectionDomain.getCodeSource.getLocation.toURI.getPath;val manifest = new JarInputStream(new FileInputStream(scala3LibJar)).getManifest;val ver = manifest.getMainAttributes.getValue("Implementation-Version");@main def main = println(s"Scala version ${ver}")' > test.scala && scala --server=false test.scala ;; \
-  esac && rm test.scala
-
 # Add and use user sbtuser
 RUN groupadd --gid $GROUP_ID sbtuser && useradd --gid $GROUP_ID --uid $USER_ID sbtuser --shell /bin/bash
 ENV HOME=/home/sbtuser

--- a/graalvm-jdk-community/Dockerfile
+++ b/graalvm-jdk-community/Dockerfile
@@ -39,22 +39,6 @@ RUN \
   chmod -R 755 /usr/share/sbt && \
   ln -s /usr/share/sbt/bin/sbt /usr/local/bin/sbt
 
-# Install Scala
-RUN \
-  case $SCALA_VERSION in \
-    2.*) URL=https://github.com/scala/scala/releases/download/v$SCALA_VERSION/scala-$SCALA_VERSION.tgz SCALA_DIR=/usr/share/scala-$SCALA_VERSION ;; \
-    *) URL=https://github.com/scala/scala3/releases/download/$SCALA_VERSION/scala3-$SCALA_VERSION.tar.gz SCALA_DIR=/usr/share/scala3-$SCALA_VERSION ;; \
-  esac && \
-  curl -fsL --show-error $URL | tar xfz - -C /usr/share && \
-  mv $SCALA_DIR /usr/share/scala && \
-  chown -R root:root /usr/share/scala && \
-  chmod -R 755 /usr/share/scala && \
-  ln -s /usr/share/scala/bin/* /usr/local/bin && \
-  case $SCALA_VERSION in \
-    2*) echo "println(util.Properties.versionMsg)" > test.scala && scala -nocompdaemon test.scala ;; \
-    *) echo 'import java.io.FileInputStream;import java.util.jar.JarInputStream;val scala3LibJar = classOf[CanEqual[?, ?]].getProtectionDomain.getCodeSource.getLocation.toURI.getPath;val manifest = new JarInputStream(new FileInputStream(scala3LibJar)).getManifest;val ver = manifest.getMainAttributes.getValue("Implementation-Version");@main def main = println(s"Scala version ${ver}")' > test.scala && scala --server=false test.scala ;; \
-  esac && rm test.scala
-
 # Add and use user sbtuser
 RUN groupadd --gid $GROUP_ID sbtuser && useradd --gid $GROUP_ID --uid $USER_ID sbtuser --shell /bin/bash
 ENV HOME=/home/sbtuser


### PR DESCRIPTION
sbt resolves its own Scala per project, so the standalone scala/scalac binaries were unused for sbt builds. Drop the Scala install from every Dockerfile (and the scala-based test steps), and point users who want Scala without sbt at the [virtuslab/scala-cli](https://hub.docker.com/r/virtuslab/scala-cli) image.

The warm cache still uses the Scala version via sbt, so tags are unchanged; this just slims the images by the Scala distribution (~tens of MB each).

related to #251