### PR TITLE
Add light images (sbt-only, rolling 1.x / 2.x line tags)

### DIFF
--- a/.github/images.yml
+++ b/.github/images.yml
@@ -5,6 +5,8 @@
 #   dockerfile  - Dockerfile name within the context (default: Dockerfile)
 #   platforms   - comma-separated build platforms (drives the per-arch fan-out)
 #   dropScala   - list of "major.minor" prefixes to NOT build for this image
+#   dropSbt     - list of version prefixes of lightSbt versions to NOT build
+#                 light images for (e.g. '2.' to skip the sbt 2.x line)
 #   sbt         - sbt version override (default: the top-level SBT_VERSION)
 #   light       - also build "light" images for this entry: sbt only, no Scala
 #                 warm step (sbt is pre-warmed by its distribution). Built once
@@ -55,24 +57,29 @@ javaImage:
     platforms: 'linux/amd64,linux/arm64'
     light: true
   # https://hub.docker.com/_/eclipse-temurin/tags?page=1&name=alpine
+  # No sbt 2.x light images on Alpine: the sbt 2 native launcher does not run
+  # on musl yet, see https://github.com/sbt/sbt/issues/9319
   # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk-alpine$
   - dockerContext: 'eclipse-temurin'
     dockerfile: 'alpine.Dockerfile'
     baseImageTag: '25.0.3_9-jdk-alpine'
     platforms: 'linux/amd64,linux/arm64/v8'
     light: true
+    dropSbt: ['2.']
   # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk-alpine$
   - dockerContext: 'eclipse-temurin'
     dockerfile: 'alpine.Dockerfile'
     baseImageTag: '21.0.11_10-jdk-alpine'
     platforms: 'linux/amd64,linux/arm64/v8'
     light: true
+    dropSbt: ['2.']
   # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk-alpine$
   - dockerContext: 'eclipse-temurin'
     dockerfile: 'alpine.Dockerfile'
     baseImageTag: '17.0.19_10-jdk-alpine'
     platforms: 'linux/amd64'
     light: true
+    dropSbt: ['2.']
 
   # ===== graalvm-community (GraalVM users skew modern: no Scala 2.12) =====
   # GraalVM CE only maintains the latest line (no LTS backports), so a pinned

--- a/.github/images.yml
+++ b/.github/images.yml
@@ -6,9 +6,25 @@
 #   platforms   - comma-separated build platforms (drives the per-arch fan-out)
 #   dropScala   - list of "major.minor" prefixes to NOT build for this image
 #   sbt         - sbt version override (default: the top-level SBT_VERSION)
+#   light       - also build "light" images for this entry: sbt only, no Scala
+#                 warm step (sbt is pre-warmed by its distribution). Built once
+#                 per `lightSbt` version and published under rolling tags only:
+#                 <java-major>_<sbt-line> and <java-full>_<sbt-line>, e.g.
+#                 eclipse-temurin-25_1.x and eclipse-temurin-25.0.1_8_1.x. The
+#                 exact sbt version is never in the tag (sbt releases ~monthly
+#                 and the user's project/build.properties picks it anyway); we
+#                 still pin it here so the warm cache is reproducible/rollbackable.
 
 # renovate: datasource=github-releases depName=sbt/sbt extractVersion=^v(?<version>.+)$
 SBT_VERSION: '1.12.11'
+
+# Latest sbt version per line, used to warm the light images. One entry per major
+# line (the rolling <java>_<line> tag would be ambiguous otherwise).
+lightSbt:
+  # renovate: datasource=github-releases depName=sbt/sbt extractVersion=^v(?<version>.+)$
+  - '1.12.11'
+  # renovate: datasource=github-releases depName=sbt/sbt extractVersion=^v(?<version>.+)$ versioning=regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-RC(?<build>\\d+)$
+  - '2.0.0-RC15'
 
 scalaVersion:
   # renovate: datasource=github-releases depName=scala/scala extractVersion=^v(?<version>.+)$ versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
@@ -21,36 +37,42 @@ scalaVersion:
   - '3.8.4'
 
 javaImage:
-  # ===== eclipse-temurin =====
+  # ===== eclipse-temurin (also published as light images) =====
   # https://hub.docker.com/_/eclipse-temurin/tags
   # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk$
   - dockerContext: 'eclipse-temurin'
     baseImageTag: '25.0.3_9-jdk'
     platforms: 'linux/amd64,linux/arm64'
+    light: true
   # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk$
   - dockerContext: 'eclipse-temurin'
     baseImageTag: '21.0.11_10-jdk'
     platforms: 'linux/amd64,linux/arm64'
+    light: true
   # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk$
   - dockerContext: 'eclipse-temurin'
     baseImageTag: '17.0.19_10-jdk'
     platforms: 'linux/amd64,linux/arm64'
+    light: true
   # https://hub.docker.com/_/eclipse-temurin/tags?page=1&name=alpine
   # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk-alpine$
   - dockerContext: 'eclipse-temurin'
     dockerfile: 'alpine.Dockerfile'
     baseImageTag: '25.0.3_9-jdk-alpine'
     platforms: 'linux/amd64,linux/arm64/v8'
+    light: true
   # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk-alpine$
   - dockerContext: 'eclipse-temurin'
     dockerfile: 'alpine.Dockerfile'
     baseImageTag: '21.0.11_10-jdk-alpine'
     platforms: 'linux/amd64,linux/arm64/v8'
+    light: true
   # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk-alpine$
   - dockerContext: 'eclipse-temurin'
     dockerfile: 'alpine.Dockerfile'
     baseImageTag: '17.0.19_10-jdk-alpine'
     platforms: 'linux/amd64'
+    light: true
 
   # ===== graalvm-community (GraalVM users skew modern: no Scala 2.12) =====
   # GraalVM CE only maintains the latest line (no LTS backports), so a pinned
@@ -86,23 +108,3 @@ javaImage:
   - dockerContext: 'amazoncorretto'
     baseImageTag: '17.0.19-al2023'
     platforms: 'linux/amd64'
-
-  # ===== sbt 2.0 release-candidate preview (eclipse-temurin LTS + latest, Scala 3 only) =====
-  # amd64 only: sbt 2.0 leaves a background server writing into target/ after the
-  # client returns, which races the warm-cache cleanup (`rm -r target`) on fast
-  # native arm64. Revisit (and restore arm64) once the warm cache shuts the
-  # sbt server down before cleanup.
-  # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk$
-  - dockerContext: 'eclipse-temurin'
-    baseImageTag: '25.0.3_9-jdk'
-    platforms: 'linux/amd64'
-    dropScala: ['2.12', '2.13']
-    # renovate: datasource=github-releases depName=sbt/sbt extractVersion=^v(?<version>.+)$ versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-RC(?<build>\d+)$
-    sbt: '2.0.0-RC15'
-  # renovate: datasource=docker depName=eclipse-temurin versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)_(?<build>\d+)-jdk$
-  - dockerContext: 'eclipse-temurin'
-    baseImageTag: '21.0.11_10-jdk'
-    platforms: 'linux/amd64'
-    dropScala: ['2.12', '2.13']
-    # renovate: datasource=github-releases depName=sbt/sbt extractVersion=^v(?<version>.+)$ versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-RC(?<build>\d+)$
-    sbt: '2.0.0-RC15'

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -28,7 +28,7 @@
     },
     {
       "customType": "regex",
-      "description": "Scala versions in the build matrix (one entry per `# renovate:` comment)",
+      "description": "Scala versions and the light-image sbt versions (any `# renovate:` list entry)",
       "managerFilePatterns": [
         "/^\\.github/images\\.yml$/"
       ],

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,10 +43,13 @@ jobs:
       id: gen
       run: |
         data=$(yq -o=json '.' .github/images.yml)
-        # jq helpers: derive the public "<java>" tag label per distro, and the
-        # Scala versions to build for an image (global list minus its dropScala
-        # "major.minor" prefixes). Duplicated in both programs as jq has no shared
-        # library here.
+        # jq helpers (duplicated in both programs; jq has no shared library here):
+        #   imageLabel  - public "<java>" tag label, full JDK version (e.g.
+        #                 eclipse-temurin-25.0.1_8, eclipse-temurin-alpine-25.0.1_8)
+        #   majorLabel  - same but only the JDK major (e.g. eclipse-temurin-25)
+        #   scalasFor   - Scala versions to build for an image (global list minus
+        #                 the image's dropScala "major.minor" prefixes)
+        #   sbtLine     - rolling line for an sbt version (1.12.11 -> 1.x)
         defs='
           def imageLabel($img):
             $img.dockerContext as $c | $img.baseImageTag as $t
@@ -57,44 +60,63 @@ jobs:
               elif $c == "graalvm-jdk-community" then "graalvm-jdk-community-" + ($t | sub("-ol[0-9]+$";""))
               elif $c == "amazoncorretto" then "amazoncorretto-al2023-" + ($t | sub("-al2023$";""))
               else error("unknown dockerContext: \($c)") end;
+          def majorLabel($img):
+            ($img.baseImageTag | capture("^(?<m>[0-9]+)").m) as $maj
+            | (imageLabel($img) | sub("[0-9].*$"; $maj));
           def scalasFor($root; $img):
             [ $root.scalaVersion[] | . as $s
               | select([ ($img.dropScala // [])[] as $p | $s | startswith($p) ] | any | not) ];
+          def sbtLine($sbt): ($sbt | capture("^(?<m>[0-9]+)").m) + ".x";
         '
-        # build matrix: one job per scala x image x platform (native runner per arch)
+        # build matrix: fat (javaImage x scala) + light (light:true x lightSbt),
+        # one job per (image, sbt[, scala], platform). `key` is the build identity
+        # used for the cache scope and digest artifact name. For fat it is also the
+        # published tag (<java>_<sbt>_<scala>); for light it is <java-full>_<sbt>
+        # (exact sbt, unique per build) while the published tags are rolling lines
+        # assembled in the merge job. Empty scala -> no Scala warm step (Dockerfile).
         build=$(echo "$data" | jq -c "$defs"'
+          def entry($img; $scala; $sbt; $key; $platform):
+            { scala: $scala,
+              context: $img.dockerContext,
+              dockerfile: ($img.dockerfile // "Dockerfile"),
+              baseImageTag: $img.baseImageTag,
+              key: $key,
+              platform: $platform,
+              platformId: ($platform | sub("^linux/";"") | gsub("/";"-")),
+              runner: (if ($platform | startswith("linux/arm64")) then "ubuntu-24.04-arm" else "ubuntu-24.04" end),
+              sbt: $sbt };
           . as $root
-          | [ $root.javaImage[] as $img
-              | (scalasFor($root; $img))[] as $scala
-              | ($img.platforms | split(",")[]) as $platform
-              | {
-                  scala: $scala,
-                  context: $img.dockerContext,
-                  dockerfile: ($img.dockerfile // "Dockerfile"),
-                  baseImageTag: $img.baseImageTag,
-                  label: imageLabel($img),
-                  platform: $platform,
-                  platformId: ($platform | sub("^linux/";"") | gsub("/";"-")),
-                  runner: (if ($platform | startswith("linux/arm64")) then "ubuntu-24.04-arm" else "ubuntu-24.04" end),
-                  sbt: ($img.sbt // $root.SBT_VERSION)
-                } ]')
-        # merge matrix: one job per final tag (scala x image)
+          | ( [ $root.javaImage[] as $img
+                | (scalasFor($root; $img))[] as $scala
+                | ($img.sbt // $root.SBT_VERSION) as $sbt
+                | ($img.platforms | split(",")[]) as $platform
+                | entry($img; $scala; $sbt; (imageLabel($img) + "_" + $sbt + "_" + $scala); $platform) ]
+            + [ $root.javaImage[] as $img | select($img.light == true)
+                | $root.lightSbt[] as $sbt
+                | ($img.platforms | split(",")[]) as $platform
+                | entry($img; ""; $sbt; (imageLabel($img) + "_" + $sbt); $platform) ] )')
+        # merge matrix: one job per build identity (`key`, matches the digest
+        # artifacts) listing the published tags (`tags`, space-separated). Fat tags
+        # publish a single <java>_<sbt>_<scala>; light publishes two rolling tags
+        # per line: <java-major>_<line> and <java-full>_<line> on the same digests.
         merge=$(echo "$data" | jq -c "$defs"'
           . as $root
-          | [ $root.javaImage[] as $img
-              | (scalasFor($root; $img))[] as $scala
-              | {
-                  scala: $scala,
-                  label: imageLabel($img),
-                  platformCount: ($img.platforms | split(",") | length),
-                  sbt: ($img.sbt // $root.SBT_VERSION)
-                } ]')
+          | ( [ $root.javaImage[] as $img
+                | (scalasFor($root; $img))[] as $scala
+                | (imageLabel($img) + "_" + ($img.sbt // $root.SBT_VERSION) + "_" + $scala) as $t
+                | { key: $t, tags: $t, platformCount: ($img.platforms | split(",") | length) } ]
+            + [ $root.javaImage[] as $img | select($img.light == true)
+                | $root.lightSbt[] as $sbt
+                | sbtLine($sbt) as $line
+                | { key: (imageLabel($img) + "_" + $sbt),
+                    tags: (majorLabel($img) + "_" + $line + " " + imageLabel($img) + "_" + $line),
+                    platformCount: ($img.platforms | split(",") | length) } ] )')
         echo "build={\"include\":$build}" >> "$GITHUB_OUTPUT"
         echo "merge={\"include\":$merge}" >> "$GITHUB_OUTPUT"
     - name: Show matrices
       run: |
         echo '${{ steps.gen.outputs.build }}' | jq '.include | length as $n | "build jobs: \($n)"'
-        echo '${{ steps.gen.outputs.merge }}' | jq '.include | length as $n | "merge jobs (tags): \($n)"'
+        echo '${{ steps.gen.outputs.merge }}' | jq -r '.include[] | "  " + .tags'
 
   build:
     needs: prepare
@@ -119,7 +141,7 @@ jobs:
           BASE_IMAGE_TAG=${{ matrix.baseImageTag }}
           SBT_VERSION=${{ matrix.sbt }}
           SCALA_VERSION=${{ matrix.scala }}
-        cache-to: type=gha,mode=max,scope=${{ matrix.label }}-${{ matrix.sbt }}-${{ matrix.scala }}-${{ matrix.platformId }}
+        cache-to: type=gha,mode=max,scope=${{ matrix.key }}-${{ matrix.platformId }}
     - name: Test image as root (default)
       run: docker run --rm scala-sbt:test sbt --script-version
     - name: Test image as sbtuser
@@ -144,7 +166,7 @@ jobs:
         platforms: ${{ matrix.platform }}
         # Reuses the layers just built for the test above (same run, same scope),
         # so this does not rebuild from scratch.
-        cache-from: type=gha,scope=${{ matrix.label }}-${{ matrix.sbt }}-${{ matrix.scala }}-${{ matrix.platformId }}
+        cache-from: type=gha,scope=${{ matrix.key }}-${{ matrix.platformId }}
         build-args: |
           BASE_IMAGE_TAG=${{ matrix.baseImageTag }}
           SBT_VERSION=${{ matrix.sbt }}
@@ -160,7 +182,7 @@ jobs:
       if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
       uses: actions/upload-artifact@v7
       with:
-        name: digest-${{ matrix.label }}_${{ matrix.sbt }}_${{ matrix.scala }}-${{ matrix.platformId }}
+        name: digest-${{ matrix.key }}-${{ matrix.platformId }}
         path: /tmp/digests/*
         if-no-files-found: error
         retention-days: 1
@@ -175,11 +197,11 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.prepare.outputs.merge) }}
     steps:
-    - name: Download digests for ${{ matrix.label }} / scala ${{ matrix.scala }}
+    - name: Download digests for ${{ matrix.key }}
       uses: actions/download-artifact@v8
       with:
         path: /tmp/digests
-        pattern: digest-${{ matrix.label }}_${{ matrix.sbt }}_${{ matrix.scala }}-*
+        pattern: digest-${{ matrix.key }}-*
         merge-multiple: true
     - name: Set up Docker Buildx
       uses: docker/setup-buildx-action@v4.1.0
@@ -192,7 +214,6 @@ jobs:
       working-directory: /tmp/digests
       run: |
         shopt -s nullglob
-        tag="${IMAGE}:${{ matrix.label }}_${{ matrix.sbt }}_${{ matrix.scala }}"
         digests=( * )
         expected=${{ matrix.platformCount }}
         # Fail (rather than silently skip) when not all architectures are present,
@@ -200,8 +221,13 @@ jobs:
         # the failed build re-uploads its digest and this job re-runs to push it.
         # fail-fast: false keeps this from affecting the other tags.
         if [ "${#digests[@]}" -ne "$expected" ]; then
-          echo "::error title=Incomplete::${#digests[@]}/${expected} architectures available for ${tag}; not publishing. Re-run the failed build job(s) then this job to recover."
+          echo "::error title=Incomplete::${#digests[@]}/${expected} architectures available for '${{ matrix.key }}'; not publishing. Re-run the failed build job(s) then this job to recover."
           exit 1
         fi
-        docker buildx imagetools create -t "$tag" "${digests[@]/#/${IMAGE}@sha256:}"
-        docker buildx imagetools inspect "$tag"
+        # One build can publish several tags (light images get rolling
+        # <java-major>_<line> and <java-full>_<line> on the same digests).
+        read -ra names <<< "${{ matrix.tags }}"
+        targs=()
+        for n in "${names[@]}"; do targs+=( -t "${IMAGE}:${n}" ); done
+        docker buildx imagetools create "${targs[@]}" "${digests[@]/#/${IMAGE}@sha256:}"
+        for n in "${names[@]}"; do docker buildx imagetools inspect "${IMAGE}:${n}"; done

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,6 +49,8 @@ jobs:
         #   majorLabel  - same but only the JDK major (e.g. eclipse-temurin-25)
         #   scalasFor   - Scala versions to build for an image (global list minus
         #                 the image's dropScala "major.minor" prefixes)
+        #   lightSbtsFor - lightSbt versions to build for an image (global list
+        #                 minus the image's dropSbt prefixes)
         #   sbtLine     - rolling line for an sbt version (1.12.11 -> 1.x)
         defs='
           def imageLabel($img):
@@ -66,6 +68,9 @@ jobs:
           def scalasFor($root; $img):
             [ $root.scalaVersion[] | . as $s
               | select([ ($img.dropScala // [])[] as $p | $s | startswith($p) ] | any | not) ];
+          def lightSbtsFor($root; $img):
+            [ $root.lightSbt[] | . as $s
+              | select([ ($img.dropSbt // [])[] as $p | $s | startswith($p) ] | any | not) ];
           def sbtLine($sbt): ($sbt | capture("^(?<m>[0-9]+)").m) + ".x";
         '
         # build matrix: fat (javaImage x scala) + light (light:true x lightSbt),
@@ -92,7 +97,7 @@ jobs:
                 | ($img.platforms | split(",")[]) as $platform
                 | entry($img; $scala; $sbt; (imageLabel($img) + "_" + $sbt + "_" + $scala); $platform) ]
             + [ $root.javaImage[] as $img | select($img.light == true)
-                | $root.lightSbt[] as $sbt
+                | (lightSbtsFor($root; $img))[] as $sbt
                 | ($img.platforms | split(",")[]) as $platform
                 | entry($img; ""; $sbt; (imageLabel($img) + "_" + $sbt); $platform) ] )')
         # merge matrix: one job per build identity (`key`, matches the digest
@@ -106,7 +111,7 @@ jobs:
                 | (imageLabel($img) + "_" + ($img.sbt // $root.SBT_VERSION) + "_" + $scala) as $t
                 | { key: $t, tags: $t, platformCount: ($img.platforms | split(",") | length) } ]
             + [ $root.javaImage[] as $img | select($img.light == true)
-                | $root.lightSbt[] as $sbt
+                | (lightSbtsFor($root; $img))[] as $sbt
                 | sbtLine($sbt) as $line
                 | { key: (imageLabel($img) + "_" + $sbt),
                     tags: (majorLabel($img) + "_" + $line + " " + imageLabel($img) + "_" + $line),

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ release. Each light image is published under two tags:
   (plain Dependabot can bump it), sbt still rolls.
 
 Light images are built for **sbt 1.x and sbt 2.x** (sbt 2.x requires JDK 17+).
+The Alpine variants are 1.x only for now: the sbt 2 native launcher does not run
+on musl yet ([sbt/sbt#9319](https://github.com/sbt/sbt/issues/9319)).
 
 ```
 docker run -it --rm sbtscala/scala-sbt:eclipse-temurin-25_1.x          # light, JDK + sbt 1.x latest

--- a/README.md
+++ b/README.md
@@ -2,7 +2,25 @@
 
 This repository provides [sbt](http://www.scala-sbt.org) Docker files and images for building [Scala](http://www.scala-lang.org) projects. The images install sbt (which resolves the project's Scala version itself); a standalone `scala` CLI is not bundled.
 
-As we think referencing unstable versions is a bad idea we don't publish a `latest` tag. Our tags consists of three parts: `<JDK version>_<sbt version>_<Scala version>`.
+As we think referencing unstable versions is a bad idea we don't publish a `latest` tag. The full ("fat") tags consist of three parts: `<JDK version>_<sbt version>_<Scala version>`, where a trivial project is pre-compiled so the Scala compiler is also warmed.
+
+There are also **light** images (no Scala warmup). sbt resolves the Scala version your
+project needs at build time, so the Scala part is unnecessary; and your
+`project/build.properties` already pins the exact sbt, so the light tags only
+track the sbt *line* (`1.x` / `2.x`), which always rolls forward to the latest
+release. Each light image is published under two tags:
+
+* `<JDK major>_<sbt line>`, e.g. `eclipse-temurin-25_1.x` - JDK and sbt both roll
+  forward to the latest. Convenient, nothing to update.
+* `<JDK version>_<sbt line>`, e.g. `eclipse-temurin-25.0.1_8_1.x` - pin the JDK
+  (plain Dependabot can bump it), sbt still rolls.
+
+Light images are built for **sbt 1.x and sbt 2.x** (sbt 2.x requires JDK 17+).
+
+```
+docker run -it --rm sbtscala/scala-sbt:eclipse-temurin-25_1.x          # light, JDK + sbt 1.x latest
+docker run -it --rm sbtscala/scala-sbt:eclipse-temurin-25.0.1_8_2.x    # light, pinned JDK + sbt 2.x latest
+```
 
 Images are updated daily
 

--- a/eclipse-temurin/Dockerfile
+++ b/eclipse-temurin/Dockerfile
@@ -9,8 +9,13 @@ ARG BASE_IMAGE_TAG
 FROM eclipse-temurin:${BASE_IMAGE_TAG:-11.0.16.1_1-jdk}
 
 # Env variables
-ARG SCALA_VERSION
-ENV SCALA_VERSION=${SCALA_VERSION:-2.13.10}
+# Default only applies when the build arg is unset (manual builds). The build
+# workflow passes SCALA_VERSION explicitly: a value for fat images, an empty
+# string for light images. Using an ARG default (not ${VAR:-...}, which also
+# fires on an empty value) keeps an explicit empty arg empty, so light images
+# skip the Scala warm-up below.
+ARG SCALA_VERSION=2.13.10
+ENV SCALA_VERSION=${SCALA_VERSION}
 ARG SBT_VERSION
 ENV SBT_VERSION=${SBT_VERSION:-1.6.2}
 ARG USER_ID
@@ -50,17 +55,22 @@ USER sbtuser
 # Switch working directory
 WORKDIR /home/sbtuser
 
-# Prepare sbt (warm cache)
+# Prepare sbt (warm cache). With a Scala version set, also pre-compile a tiny
+# project so the Scala compiler + bridge are cached (fat images). Light images
+# pass an empty SCALA_VERSION and only warm sbt (which ships preloaded in its
+# distribution), so there is no Scala in the tag.
 RUN \
   umask 0002 && \
   sbt --script-version && \
-  mkdir -p project && \
-  echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \
-  echo "sbt.version=${SBT_VERSION}" > project/build.properties && \
-  echo "// force sbt compiler-bridge download" > project/Dependencies.scala && \
-  echo "case object Temp" > Temp.scala && \
-  sbt compile && \
-  rm -r project && rm build.sbt && rm Temp.scala && rm -r target
+  if [ -n "${SCALA_VERSION}" ]; then \
+    mkdir -p project && \
+    echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \
+    echo "sbt.version=${SBT_VERSION}" > project/build.properties && \
+    echo "// force sbt compiler-bridge download" > project/Dependencies.scala && \
+    echo "case object Temp" > Temp.scala && \
+    sbt compile && \
+    rm -r project && rm build.sbt && rm Temp.scala && rm -r target ; \
+  fi
 
 # Link everything into root as well
 # This allows users of this container to choose, whether they want to run the container as sbtuser (non-root) or as root

--- a/eclipse-temurin/alpine.Dockerfile
+++ b/eclipse-temurin/alpine.Dockerfile
@@ -49,18 +49,23 @@ USER sbtuser
 # Switch working directory
 WORKDIR /home/sbtuser
 
-# Prepare sbt (warm cache)
+# Prepare sbt (warm cache). With a Scala version set, also pre-compile a tiny
+# project so the Scala compiler + bridge are cached (fat images). Light images
+# pass an empty SCALA_VERSION and only warm sbt (which ships preloaded in its
+# distribution), so there is no Scala in the tag.
 RUN \
   umask 0002 && \
   sbt --script-version && \
-  mkdir -p project && \
-  echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \
-  echo "sbt.version=${SBT_VERSION}" > project/build.properties && \
-  echo "// force sbt compiler-bridge download" > project/Dependencies.scala && \
-  echo "case object Temp" > Temp.scala && \
-  sbt sbtVersion && \
-  sbt compile && \
-  rm -r project && rm build.sbt && rm Temp.scala && rm -r target
+  if [ -n "${SCALA_VERSION}" ]; then \
+    mkdir -p project && \
+    echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \
+    echo "sbt.version=${SBT_VERSION}" > project/build.properties && \
+    echo "// force sbt compiler-bridge download" > project/Dependencies.scala && \
+    echo "case object Temp" > Temp.scala && \
+    sbt sbtVersion && \
+    sbt compile && \
+    rm -r project && rm build.sbt && rm Temp.scala && rm -r target ; \
+  fi
 
 # Link everything into root as well
 # This allows users of this container to choose, whether they want to run the container as sbtuser (non-root) or as root


### PR DESCRIPTION
sbt-only variant for issue #251: skips the Scala warm-up (`sbt compile`) since sbt resolves Scala per project. sbt itself stays warm via its distribution's preloaded repo.

### Tags

The exact sbt version is not in the tag (sbt releases ~twice a month, and a project's `build.properties` picks its own sbt anyway). Each light image gets two rolling tags on the same digest:

| Tag | Example | Behaviour |
| --- | --- | --- |
| `<JDK major>_<sbt line>` | `eclipse-temurin-25_1.x` | JDK + sbt both roll to latest |
| `<JDK version>_<sbt line>` | `eclipse-temurin-25.0.1_8_1.x` | pinned JDK (Dependabot-bumpable), sbt rolls |

sbt is still pinned in `images.yml` (Renovate-tracked, rollback-able). Built for sbt 1.x and 2.x, eclipse-temurin jdk + alpine 17/21/25. The fat sbt-2.0 RC preview is dropped in favour of light.

### Implementation

- `images.yml`: `light: true` on the temurin entries (JDK versions tracked once) + a `lightSbt` list
- `build.yml`: build-identity `key` (cache/digest) separate from published `tags`; merge emits both rolling tags in one `imagetools create`
- Dockerfiles: warm-cache compile conditional on `SCALA_VERSION`

### Open questions

1. Tag format ok (`_` separator)?
2. Light is temurin-only - extend to graalvm / corretto?

closes #251
