### PR TITLE
Renovate: pick the newest GraalVM OL variant

### DIFF
--- a/.github/images.yml
+++ b/.github/images.yml
@@ -57,7 +57,7 @@ javaImage:
   # major goes stale and unfixable. We ship a single entry that tracks the
   # latest release; Renovate may bump it across majors (see renovate.json).
   # https://github.com/graalvm/container/pkgs/container/graalvm-community
-  # renovate: datasource=docker depName=ghcr.io/graalvm/graalvm-community versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-ol\d+$
+  # renovate: datasource=docker depName=ghcr.io/graalvm/graalvm-community versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-ol(?<build>\d+)$
   - dockerContext: 'graalvm-community'
     baseImageTag: '25.0.1-ol10'
     platforms: 'linux/amd64,linux/arm64'
@@ -66,7 +66,7 @@ javaImage:
   # ===== graalvm-jdk-community (compact GraalVM JDK, no native-image; no Scala 2.12) =====
   # Latest-only, same rationale as graalvm-community above.
   # https://github.com/graalvm/container/pkgs/container/jdk-community
-  # renovate: datasource=docker depName=ghcr.io/graalvm/jdk-community versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-ol\d+$
+  # renovate: datasource=docker depName=ghcr.io/graalvm/jdk-community versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)-ol(?<build>\d+)$
   - dockerContext: 'graalvm-jdk-community'
     baseImageTag: '25.0.1-ol10'
     platforms: 'linux/amd64,linux/arm64'


### PR DESCRIPTION
The -ol suffix was matched but not captured, so all OL variants of a release compared equal and Renovate could pick any of them. Capture the OL number as the build group so the newest one sorts highest.