### PR TITLE
Surface in-minor Scala patch updates in Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -69,6 +69,12 @@
       "enabled": false
     },
     {
+      "description": "Split patch from minor for Scala so an in-minor patch (e.g. 3.3.7 -> 3.3.8) is not swallowed by a newer minor and survives the rule above",
+      "matchDatasources": ["github-releases"],
+      "matchPackageNames": ["scala/scala", "scala/scala3"],
+      "separateMinorPatch": true
+    },
+    {
       "description": "Keep sbt on the 1.x line (2.0 is added as a separate matrix dimension)",
       "matchDatasources": ["github-releases"],
       "matchPackageNames": ["sbt/sbt"],


### PR DESCRIPTION
Renovate's separateMinorPatch defaults to false, so it collapses all non-major updates into one branch targeting the highest version (e.g. 3.8.4). The existing rule disables minor/major for Scala, which then suppresses that branch entirely and swallows the intervening patch (3.3.7 -> 3.3.8), so no PR is ever opened.

Enable separateMinorPatch for scala/scala and scala/scala3 so the patch update is generated as its own branch and survives the minor/major block.