### PR TITLE
Bump sbt 2.x light image to 2.0.0 final

### DIFF
--- a/.github/images.yml
+++ b/.github/images.yml
@@ -25,8 +25,8 @@ SBT_VERSION: '1.12.12'
 lightSbt:
   # renovate: datasource=github-releases depName=sbt/sbt extractVersion=^v(?<version>.+)$
   - '1.12.12'
-  # renovate: datasource=github-releases depName=sbt/sbt extractVersion=^v(?<version>.+)$ versioning=regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)-RC(?<build>\\d+)$
-  - '2.0.0-RC15'
+  # renovate: datasource=github-releases depName=sbt/sbt extractVersion=^v(?<version>.+)$ versioning=regex:^(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$
+  - '2.0.0'
 
 scalaVersion:
   # renovate: datasource=github-releases depName=scala/scala extractVersion=^v(?<version>.+)$ versioning=regex:^(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$


### PR DESCRIPTION
The RC-only versioning regex could not advance past the final release (2.0.0 has no -RC<build> suffix), so switch the entry to plain semver versioning. Renovate now tracks 2.0.x patches automatically.