### PR TITLE
Fix light images failing to run sbt as root (#401)

### DIFF
--- a/.github/images.yml
+++ b/.github/images.yml
@@ -8,8 +8,9 @@
 #   dropSbt     - list of version prefixes of lightSbt versions to NOT build
 #                 light images for (e.g. '2.' to skip the sbt 2.x line)
 #   sbt         - sbt version override (default: the top-level SBT_VERSION)
-#   light       - also build "light" images for this entry: sbt only, no Scala
-#                 warm step (sbt is pre-warmed by its distribution). Built once
+#   light       - also build "light" images for this entry: no warmup at all
+#                 (neither sbt nor Scala); sbt is installed but its runtime, the
+#                 Scala toolchain and deps are resolved on first run. Built once
 #                 per `lightSbt` version and published under rolling tags only:
 #                 <java-major>_<sbt-line> and <java-full>_<sbt-line>, e.g.
 #                 eclipse-temurin-25_1.x and eclipse-temurin-25.0.1_8_1.x. The

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,9 +175,13 @@ jobs:
           SCALA_VERSION=${{ matrix.scala }}
         cache-to: type=gha,mode=max,scope=${{ matrix.key }}-${{ matrix.platformId }}
     - name: Test image as root (default)
-      run: docker run --rm scala-sbt:test sbt --script-version
+      # fully boot sbt (not just --script-version): this is the default run path
+      # and the only one that follows the /root/.sbt and /root/.cache symlinks,
+      # which were left dangling on light images (see #401). touch build.sbt so
+      # sbt does not refuse an empty directory.
+      run: docker run --rm scala-sbt:test /bin/bash -c "touch build.sbt && sbt exit"
     - name: Test image as sbtuser
-      run: docker run --rm -u sbtuser -w /home/sbtuser scala-sbt:test sbt --script-version
+      run: docker run --rm -u sbtuser -w /home/sbtuser scala-sbt:test /bin/bash -c "touch build.sbt && sbt exit"
     - name: Test image launches as an arbitrary uid (issue #258)
       # write a build file (also checks the home dir is writable) then fully
       # launch sbt, which exercises the temp/HOME writes that previously failed

--- a/README.md
+++ b/README.md
@@ -2,13 +2,18 @@
 
 This repository provides [sbt](http://www.scala-sbt.org) Docker files and images for building [Scala](http://www.scala-lang.org) projects. The images install sbt (which resolves the project's Scala version itself); a standalone `scala` CLI is not bundled.
 
-As we think referencing unstable versions is a bad idea we don't publish a `latest` tag. The full ("fat") tags consist of three parts: `<JDK version>_<sbt version>_<Scala version>`, where a trivial project is pre-compiled so the Scala compiler is also warmed.
+As we think referencing unstable versions is a bad idea we don't publish a `latest` tag. The full ("fat") tags consist of three parts: `<JDK version>_<sbt version>_<Scala version>`, where a trivial project is pre-compiled so that **both sbt and the Scala compiler are warmed** (downloaded and cached in the image).
 
-There are also **light** images (no Scala warmup). sbt resolves the Scala version your
-project needs at build time, so the Scala part is unnecessary; and your
-`project/build.properties` already pins the exact sbt, so the light tags only
-track the sbt *line* (`1.x` / `2.x`), which always rolls forward to the latest
-release. Each light image is published under two tags:
+There are also **light** images. These do **no warmup at all** - neither sbt nor
+Scala. They simply ship the JDK with sbt installed and the user/permissions set
+up; sbt downloads its own runtime, the Scala toolchain, and your dependencies on
+first run. The point is convenience (a ready-to-use, correctly configured sbt
+environment), not a warm cache - warming a specific sbt/Scala only pays off in
+the fat images, and a light image's pinned versions would rarely match your
+project anyway (sbt resolves the Scala version your project needs, and your
+`project/build.properties` pins the exact sbt). So the light tags carry no Scala
+part and only track the sbt *line* (`1.x` / `2.x`), which always rolls forward to
+the latest release. Each light image is published under two tags:
 
 * `<JDK major>_<sbt line>`, e.g. `eclipse-temurin-25_1.x` - JDK and sbt both roll
   forward to the latest. Convenient, nothing to update.

--- a/eclipse-temurin/Dockerfile
+++ b/eclipse-temurin/Dockerfile
@@ -55,13 +55,14 @@ USER sbtuser
 # Switch working directory
 WORKDIR /home/sbtuser
 
-# Prepare sbt (warm cache). With a Scala version set, also pre-compile a tiny
-# project so the Scala compiler + bridge are cached (fat images). Light images
-# pass an empty SCALA_VERSION and only warm sbt (which ships preloaded in its
-# distribution), so there is no Scala in the tag.
+# Prepare sbt. For fat images (a Scala version is set) compile a tiny project so
+# the Scala compiler + bridge are cached. Light images pass an empty SCALA_VERSION:
+# they ship sbt pre-installed but unwarmed (the user's project/build.properties
+# picks the sbt version at runtime anyway), so we only create ~/.sbt and ~/.cache,
+# which the root symlinks below point at. The dirs must exist or those symlinks
+# dangle and `docker run ... sbt` fails as root in the launcher (see #401).
 RUN \
   umask 0002 && \
-  sbt --script-version && \
   if [ -n "${SCALA_VERSION}" ]; then \
     mkdir -p project && \
     echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \
@@ -70,6 +71,8 @@ RUN \
     echo "case object Temp" > Temp.scala && \
     sbt compile && \
     rm -r project && rm build.sbt && rm Temp.scala && rm -r target ; \
+  else \
+    mkdir -p .sbt .cache ; \
   fi
 
 # Link everything into root as well
@@ -77,8 +80,8 @@ RUN \
 USER root
 RUN \
   rm -rf /tmp/..?* /tmp/.[!.]* * && \
-  ln -s /home/sbtuser/.cache /root/.cache && \
-  ln -s /home/sbtuser/.sbt /root/.sbt && \
+  if [ -d "/home/sbtuser/.cache" ]; then ln -s /home/sbtuser/.cache /root/.cache; fi && \
+  if [ -d "/home/sbtuser/.sbt" ]; then ln -s /home/sbtuser/.sbt /root/.sbt; fi && \
   if [ -d "/home/sbtuser/.ivy2" ]; then ln -s /home/sbtuser/.ivy2 /root/.ivy2; fi
 
 # Switch working directory back to root

--- a/eclipse-temurin/alpine.Dockerfile
+++ b/eclipse-temurin/alpine.Dockerfile
@@ -49,13 +49,14 @@ USER sbtuser
 # Switch working directory
 WORKDIR /home/sbtuser
 
-# Prepare sbt (warm cache). With a Scala version set, also pre-compile a tiny
-# project so the Scala compiler + bridge are cached (fat images). Light images
-# pass an empty SCALA_VERSION and only warm sbt (which ships preloaded in its
-# distribution), so there is no Scala in the tag.
+# Prepare sbt. For fat images (a Scala version is set) compile a tiny project so
+# the Scala compiler + bridge are cached. Light images pass an empty SCALA_VERSION:
+# they ship sbt pre-installed but unwarmed (the user's project/build.properties
+# picks the sbt version at runtime anyway), so we only create ~/.sbt and ~/.cache,
+# which the root symlinks below point at. The dirs must exist or those symlinks
+# dangle and `docker run ... sbt` fails as root in the launcher (see #401).
 RUN \
   umask 0002 && \
-  sbt --script-version && \
   if [ -n "${SCALA_VERSION}" ]; then \
     mkdir -p project && \
     echo "scalaVersion := \"${SCALA_VERSION}\"" > build.sbt && \
@@ -65,6 +66,8 @@ RUN \
     sbt sbtVersion && \
     sbt compile && \
     rm -r project && rm build.sbt && rm Temp.scala && rm -r target ; \
+  else \
+    mkdir -p .sbt .cache ; \
   fi
 
 # Link everything into root as well
@@ -72,8 +75,8 @@ RUN \
 USER root
 RUN \
   rm -rf /tmp/..?* /tmp/.[!.]* * && \
-  ln -s /home/sbtuser/.cache /root/.cache && \
-  ln -s /home/sbtuser/.sbt /root/.sbt && \
+  if [ -d "/home/sbtuser/.cache" ]; then ln -s /home/sbtuser/.cache /root/.cache; fi && \
+  if [ -d "/home/sbtuser/.sbt" ]; then ln -s /home/sbtuser/.sbt /root/.sbt; fi && \
   if [ -d "/home/sbtuser/.ivy2" ]; then ln -s /home/sbtuser/.ivy2 /root/.ivy2; fi
 
 # Switch working directory back to root


### PR DESCRIPTION
Light images ran only `sbt --script-version`, which never boots sbt, so ~/.sbt and ~/.cache were never created. The Dockerfile then symlinked /root/.sbt and /root/.cache to those missing dirs, leaving them dangling. Running the image as root (the default) booted sbt, followed the dangling links and failed in the launcher with NoSuchFileException on rt.jar.

Light images do no warmup by design (neither sbt nor Scala): the rolling sbt-line tag would rarely match the version a project pins in project/build.properties, so a warm sbt boot is mostly wasted weight. Just create ~/.sbt and ~/.cache so the dirs exist, and guard the /root symlinks so a missing source dir can never produce a dangling link again.

Also switch the root/sbtuser image tests to fully boot sbt (touch build.sbt && sbt exit) instead of --script-version, which never booted and so missed this; verified the new test fails on the broken image and passes on the fix. Document in the README and images.yml that light means no warmup at all.

fixes #401 